### PR TITLE
Bugfix/0.0.x numpy2 update

### DIFF
--- a/src/xspline/utils.py
+++ b/src/xspline/utils.py
@@ -1,4 +1,5 @@
 # utility functions for the bsplinex class
+import functools
 import math
 import numpy as np
 
@@ -446,5 +447,4 @@ def outer_flatten(*args):
         numpy.ndarray:
         1D numpy array that store the flattened outer product.
     """
-    result = np.prod(np.ix_(*args))
-    return result.reshape(result.size,)
+    return functools.reduce(np.multiply.outer, args).ravel()

--- a/src/xspline/utils.py
+++ b/src/xspline/utils.py
@@ -1,4 +1,5 @@
 # utility functions for the bsplinex class
+import math
 import numpy as np
 
 
@@ -154,7 +155,7 @@ def constant_if(a, x, order, c):
         else:
             return 0.0
 
-    return c*(x - a)**order/np.math.factorial(order)
+    return c*(x - a)**order/math.factorial(order)
 
 
 def linear_if(a, x, order, z, fz, dfz):
@@ -239,7 +240,7 @@ def integrate_across_pieces(a, x, order, funcs, knots):
     val = integrate_across_pieces(b, x, order, funcs[1:], knots[1:])
 
     for j in range(order):
-        val += funcs[0](a, b, order - j)*(x - b)**j / np.math.factorial(j)
+        val += funcs[0](a, b, order - j)*(x - b)**j / math.factorial(j)
 
     return val
 

--- a/src/xspline/utils.py
+++ b/src/xspline/utils.py
@@ -193,8 +193,8 @@ def linear_if(a, x, order, z, fz, dfz):
     fa = fz + dfz*(a - z)
     dfa = dfz
 
-    return dfa*(x - a)**(order + 1)/np.math.factorial(order + 1) + \
-        fa*(x - a)**order/np.math.factorial(order)
+    return dfa*(x - a)**(order + 1)/math.factorial(order + 1) + \
+        fa*(x - a)**order/math.factorial(order)
 
 
 def integrate_across_pieces(a, x, order, funcs, knots):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -169,8 +169,11 @@ def test_utils_option_to_list(option, size):
                          [(np.arange(2), np.arange(3)),
                           (np.arange(2), np.arange(3), np.arange(4))])
 def test_utils_outer_flatten(args):
-    result = np.prod(np.ix_(*args))
-    result = result.reshape(result.size,)
+    if len(args) < 2:
+        raise ValueError("Must have more than 2 arguments for outer_flatten.")
+    result = np.outer(args[0], args[1]).ravel()
+    for arg in args[2:]:
+        result = np.outer(result, arg).ravel()
     my_result = utils.outer_flatten(*args)
 
     assert np.linalg.norm(my_result - result) < 1e-10


### PR DESCRIPTION
## Summary

This PR tries to revised version `<0.1.0` since currently mrtool and crosswalk still are working with it. We will keep the 0.0.x branch for all above `0.0.7`, under `0.1.0` versions. We will not adding to remove any functionality from `0.0.x` versions, only fixing bugs.

numpy 2 removed/changed several APIs the package relied on, breaking the
test suite (77 failures against numpy 2.4.6). This updates the affected
code so it works under numpy 2 while keeping the same behavior.

Two distinct numpy-1→2 issues are addressed:

- `np.math.factorial` was removed in numpy 2 — replaced with the
  standard library `math.factorial`.
- `np.prod(np.ix_(*args))` in `outer_flatten` relied on numpy 1
  silently coercing the ragged tuple returned by `np.ix_` into an
  array. numpy 2 raises `ValueError: setting an array element with a
  sequence ... inhomogeneous shape`. Rewritten to compute the
  flattened outer product directly.

## What changed

- `src/xspline/utils.py` — use `math.factorial` instead of
  `np.math.factorial`; rewrite `outer_flatten` to
  `functools.reduce(np.multiply.outer, args).ravel()`; add the
  `functools` and `math` imports.
- `tests/test_utils.py` — update `test_utils_outer_flatten` to compute
  its expected result with `np.outer` instead of the now-invalid
  `np.prod(np.ix_(*args))` pattern.

## Note

Please ignore `codacy`...
