### PR TITLE
Format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,47 +3,40 @@ from pathlib import Path
 from setuptools import setup, find_packages
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     base_dir = Path(__file__).parent
-    src_dir = base_dir/'src'/'xspline'
+    src_dir = base_dir / "src" / "xspline"
 
     sys.path.insert(0, src_dir.as_posix())
     import __about__ as about
 
-    with (base_dir/'README.rst').open() as f:
+    with (base_dir / "README.rst").open() as f:
         long_description = f.read()
 
-    install_requirements = [
-        'numpy'
-    ]
+    install_requirements = ["numpy"]
 
-    test_requirements = [
-        'pytest',
-        'pytest-mock'
-    ]
+    test_requirements = ["pytest", "pytest-mock"]
 
     doc_requirements = []
 
-    setup(name=about.__title__,
-          version=about.__version__,
-
-          description=about.__summary__,
-          long_description=long_description,
-          license=about.__license__,
-          url=about.__uri__,
-
-          author=about.__author__,
-          author_email=about.__email__,
-
-          package_dir={'': 'src'},
-          packages=find_packages(where='src'),
-          include_package_data=True,
-
-          install_requires=install_requirements,
-          tests_require=test_requirements,
-          extras_require={
-              'docs': doc_requirements,
-              'test': test_requirements,
-              'dev': doc_requirements + test_requirements
-          },
-          zip_safe=False,)
+    setup(
+        name=about.__title__,
+        version=about.__version__,
+        description=about.__summary__,
+        long_description=long_description,
+        license=about.__license__,
+        url=about.__uri__,
+        author=about.__author__,
+        author_email=about.__email__,
+        package_dir={"": "src"},
+        packages=find_packages(where="src"),
+        include_package_data=True,
+        install_requires=install_requirements,
+        tests_require=test_requirements,
+        extras_require={
+            "docs": doc_requirements,
+            "test": test_requirements,
+            "dev": doc_requirements + test_requirements,
+        },
+        zip_safe=False,
+    )

--- a/src/xspline/__about__.py
+++ b/src/xspline/__about__.py
@@ -1,6 +1,12 @@
 __all__ = [
-    "__title__", "__summary__", "__uri__", "__version__", "__author__",
-    "__email__", "__license__", "__copyright__",
+    "__title__",
+    "__summary__",
+    "__uri__",
+    "__version__",
+    "__author__",
+    "__email__",
+    "__license__",
+    "__copyright__",
 ]
 
 __title__ = "xspline"

--- a/src/xspline/__init__.py
+++ b/src/xspline/__init__.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-    xspline
-    ~~~~~~~
+xspline
+~~~~~~~
 
-    xspline package
+xspline package
 """
+
 from .core import *
 from . import utils

--- a/src/xspline/__init__.py
+++ b/src/xspline/__init__.py
@@ -1,10 +1,19 @@
-# -*- coding: utf-8 -*-
-"""
-xspline
-~~~~~~~
-
-xspline package
-"""
-
 from . import utils
-from .core import *
+from .core import (
+    NDXSpline,
+    XSpline,
+    bspline_dfun,
+    bspline_domain,
+    bspline_fun,
+    bspline_ifun,
+)
+
+__all__ = [
+    "utils",
+    "bspline_domain",
+    "bspline_fun",
+    "bspline_dfun",
+    "bspline_ifun",
+    "XSpline",
+    "NDXSpline",
+]

--- a/src/xspline/__init__.py
+++ b/src/xspline/__init__.py
@@ -6,5 +6,5 @@ xspline
 xspline package
 """
 
-from .core import *
 from . import utils
+from .core import *

--- a/src/xspline/core.py
+++ b/src/xspline/core.py
@@ -11,30 +11,28 @@ from . import utils
 
 
 def bspline_domain(knots, degree, idx, l_extra=False, r_extra=False):
-    r"""Compute the support for the spline basis, knots degree and the index of
+    """Compute the support for the spline basis, knots degree and the index of
     the basis.
 
-    Args:
-        knots (numpy.ndarray):
+    Parameters
+    ----------
+    knots
         1D array that stores the knots of the splines.
-
-        degree (int):
+    degree
         A non-negative integer that indicates the degree of the polynomial.
-
-        idx (int):
+    idx
         A non-negative integer that indicates the index in the spline bases
         list.
-
-        l_extra (bool, optional):
+    l_extra
         A optional bool variable indicates that if extrapolate at left end.
         Default to be False.
-
-        r_extra (bool, optional):
+    r_extra
         A optional bool variable indicates that if extrapolate at right end.
         Default to be False.
 
-    Returns:
-        numpy.ndarray:
+    Returns
+    -------
+    numpy.ndarray
         1D array with two elements represents that left and right end of the
         support of the spline basis.
     """
@@ -57,32 +55,29 @@ def bspline_domain(knots, degree, idx, l_extra=False, r_extra=False):
 
 
 def bspline_fun(x, knots, degree, idx, l_extra=False, r_extra=False):
-    r"""Compute the spline basis.
+    """Compute the spline basis.
 
-    Args:
-        x (float | numpy.ndarray):
+    Parameters
+    ----------
+    x
         Scalar or numpy array that store the independent variables.
-
-        knots (numpy.ndarray):
+    knots
         1D array that stores the knots of the splines.
-
-        degree (int):
+    degree
         A non-negative integer that indicates the degree of the polynomial.
-
-        idx (int):
+    idx
         A non-negative integer that indicates the index in the spline bases
         list.
-
-        l_extra (bool, optional):
+    l_extra
         A optional bool variable indicates that if extrapolate at left end.
         Default to be False.
-
-        r_extra (bool, optional):
+    r_extra
         A optional bool variable indicates that if extrapolate at right end.
         Default to be False.
 
-    Returns:
-        float | numpy.ndarray:
+    Returns
+    -------
+    float | numpy.ndarray
         Function values of the corresponding spline bases.
     """
     num_knots = knots.size
@@ -120,35 +115,31 @@ def bspline_fun(x, knots, degree, idx, l_extra=False, r_extra=False):
 
 
 def bspline_dfun(x, knots, degree, order, idx, l_extra=False, r_extra=False):
-    r"""Compute the derivative of the spline basis.
+    """Compute the derivative of the spline basis.
 
-    Args:
-        x (float | numpy.ndarray):
+    Parameters
+    ----------
+    x
         Scalar or numpy array that store the independent variables.
-
-        knots (numpy.ndarray):
+    knots
         1D array that stores the knots of the splines.
-
-        degree (int):
+    degree
         A non-negative integer that indicates the degree of the polynomial.
-
-        order (int):
+    order
         A non-negative integer that indicates the order of differentiation.
-
-        idx (int):
+    idx
         A non-negative integer that indicates the index in the spline bases
         list.
-
-        l_extra (bool, optional):
+    l_extra
         A optional bool variable indicates that if extrapolate at left end.
         Default to be False.
-
-        r_extra (bool, optional):
+    r_extra
         A optional bool variable indicates that if extrapolate at right end.
         Default to be False.
 
-    Returns:
-        float | numpy.ndarray:
+    Returns
+    -------
+    float | numpy.ndarray
         Derivative values of the corresponding spline bases.
     """
     num_knots = knots.size
@@ -211,38 +202,33 @@ def bspline_dfun(x, knots, degree, order, idx, l_extra=False, r_extra=False):
 
 
 def bspline_ifun(a, x, knots, degree, order, idx, l_extra=False, r_extra=False):
-    r"""Compute the integral of the spline basis.
+    """Compute the integral of the spline basis.
 
-    Args:
-        a (float | numpy.ndarray):
+    Parameters
+    ----------
+    a
         Scalar or numpy array that store the starting point of the integration.
-
-        x (float | numpy.ndarray):
+    x
         Scalar or numpy array that store the ending point of the integration.
-
-        knots (numpy.ndarray):
+    knots
         1D array that stores the knots of the splines.
-
-        degree (int):
+    degree
         A non-negative integer that indicates the degree of the polynomial.
-
-        order (int):
+    order
         A non-negative integer that indicates the order of integration.
-
-        idx (int):
+    idx
         A non-negative integer that indicates the index in the spline bases
         list.
-
-        l_extra (bool, optional):
+    l_extra
         A optional bool variable indicates that if extrapolate at left end.
         Default to be False.
-
-        r_extra (bool, optional):
+    r_extra
         A optional bool variable indicates that if extrapolate at right end.
         Default to be False.
 
-    Returns:
-        float | numpy.ndarray:
+    Returns
+    -------
+    float | numpy.ndarray
         Integral values of the corresponding spline bases.
     """
     num_knots = knots.size
@@ -311,7 +297,50 @@ def bspline_ifun(a, x, knots, degree, order, idx, l_extra=False, r_extra=False):
 
 
 class XSpline:
-    """XSpline main class of the package."""
+    """XSpline main class of the package.
+
+    Parameters
+    ----------
+    knots
+        1D numpy array that store the knots, must including that boundary knots.
+    degree
+        A non-negative integer that indicates the degree of the spline.
+    l_linear
+        A bool variable, that if using the linear tail at left end.
+    r_linear
+        A bool variable, that if using the linear tail at right end.
+    include_first_basis
+        A bool variable, that if include the first basis of the spline.
+
+    Attributes
+    ----------
+    knots
+        Sorted and de-duplicated knots of the spline.
+    degree
+        Degree of the spline.
+    l_linear
+        If using the linear tail at left end.
+    r_linear
+        If using the linear tail at right end.
+    basis_start
+        Index of the first basis, 0 if ``include_first_basis`` else 1.
+    num_knots
+        Number of knots.
+    num_intervals
+        Number of intervals between knots.
+    inner_knots
+        Knots excluding the ones used by the linear tails.
+    lb
+        Left boundary of the domain.
+    ub
+        Right boundary of the domain.
+    inner_lb
+        Left boundary of the inner (non-linear) domain.
+    inner_ub
+        Right boundary of the inner (non-linear) domain.
+    num_spline_bases
+        Number of the spline bases.
+    """
 
     def __init__(
         self,
@@ -321,20 +350,7 @@ class XSpline:
         r_linear=False,
         include_first_basis: bool = True,
     ):
-        r"""Constructor of the XSpline class.
-
-        knots (numpy.ndarray):
-        1D numpy array that store the knots, must including that boundary knots.
-
-        degree (int):
-        A non-negative integer that indicates the degree of the spline.
-
-        l_linear (bool, optional):
-        A bool variable, that if using the linear tail at left end.
-
-        r_linear (bool, optional):
-        A bool variable, that if using the linear tail at right end.
-        """
+        """Constructor of the XSpline class."""
         # pre-process the knots vector
         knots = list(set(knots))
         knots = np.sort(np.array(knots))
@@ -369,20 +385,21 @@ class XSpline:
     def domain(self, idx, l_extra=False, r_extra=False):
         """Return the support of the XSpline.
 
-        idx (int):
-        A non-negative integer that indicates the index in the spline bases
-        list.
+        Parameters
+        ----------
+        idx
+            A non-negative integer that indicates the index in the spline bases
+            list.
+        l_extra
+            A optional bool variable indicates that if extrapolate at left end.
+            Default to be False.
+        r_extra
+            A optional bool variable indicates that if extrapolate at right end.
+            Default to be False.
 
-        l_extra (bool, optional):
-        A optional bool variable indicates that if extrapolate at left end.
-        Default to be False.
-
-        r_extra (bool, optional):
-        A optional bool variable indicates that if extrapolate at right end.
-        Default to be False.
-
-        Returns:
-            numpy.ndarray:
+        Returns
+        -------
+        numpy.ndarray
             1D array with two elements represents that left and right end of the
             support of the spline basis.
         """
@@ -398,26 +415,25 @@ class XSpline:
         return np.array([lb, ub])
 
     def fun(self, x, idx, l_extra=False, r_extra=False):
-        r"""Compute the spline basis.
+        """Compute the spline basis.
 
-        Args:
-            x (float | numpy.ndarray):
+        Parameters
+        ----------
+        x
             Scalar or numpy array that store the independent variables.
-
-            idx (int):
+        idx
             A non-negative integer that indicates the index in the spline bases
             list.
-
-            l_extra (bool, optional):
+        l_extra
             A optional bool variable indicates that if extrapolate at left end.
             Default to be False.
-
-            r_extra (bool, optional):
+        r_extra
             A optional bool variable indicates that if extrapolate at right end.
             Default to be False.
 
-        Returns:
-            float | numpy.ndarray:
+        Returns
+        -------
+        float | numpy.ndarray
             Function values of the corresponding spline bases.
         """
         if not self.l_linear and not self.r_linear:
@@ -473,29 +489,27 @@ class XSpline:
             return f
 
     def dfun(self, x, order, idx, l_extra=False, r_extra=False):
-        r"""Compute the derivative of the spline basis.
+        """Compute the derivative of the spline basis.
 
-        Args:
-            x (float | numpy.ndarray):
+        Parameters
+        ----------
+        x
             Scalar or numpy array that store the independent variables.
-
-            order (int):
+        order
             A non-negative integer that indicates the order of differentiation.
-
-            idx (int):
+        idx
             A non-negative integer that indicates the index in the spline bases
             list.
-
-            l_extra (bool, optional):
+        l_extra
             A optional bool variable indicates that if extrapolate at left end.
             Default to be False.
-
-            r_extra (bool, optional):
+        r_extra
             A optional bool variable indicates that if extrapolate at right end.
             Default to be False.
 
-        Returns:
-            float | numpy.ndarray:
+        Returns
+        -------
+        float | numpy.ndarray
             Derivative values of the corresponding spline bases.
         """
         if order == 0:
@@ -549,34 +563,31 @@ class XSpline:
             return dy
 
     def ifun(self, a, x, order, idx, l_extra=False, r_extra=False):
-        r"""Compute the integral of the spline basis.
+        """Compute the integral of the spline basis.
 
-        Args:
-            a (float | numpy.ndarray):
+        Parameters
+        ----------
+        a
             Scalar or numpy array that store the starting point of the
             integration.
-
-            x (float | numpy.ndarray):
+        x
             Scalar or numpy array that store the ending point of the
             integration.
-
-            order (int):
+        order
             A non-negative integer that indicates the order of integration.
-
-            idx (int):
+        idx
             A non-negative integer that indicates the index in the spline bases
             list.
-
-            l_extra (bool, optional):
+        l_extra
             A optional bool variable indicates that if extrapolate at left end.
             Default to be False.
-
-            r_extra (bool, optional):
+        r_extra
             A optional bool variable indicates that if extrapolate at right end.
             Default to be False.
 
-        Returns:
-            float | numpy.ndarray:
+        Returns
+        -------
+        float | numpy.ndarray
             Integral values of the corresponding spline bases.
         """
         if order == 0:
@@ -657,22 +668,22 @@ class XSpline:
         return utils.pieces_if(a, x, order, funcs, knots)
 
     def design_mat(self, x, l_extra=False, r_extra=False):
-        r"""Compute the design matrix of spline basis.
+        """Compute the design matrix of spline basis.
 
-        Args:
-            x (float | numpy.ndarray):
+        Parameters
+        ----------
+        x
             Scalar or numpy array that store the independent variables.
-
-            l_extra (bool, optional):
+        l_extra
             A optional bool variable indicates that if extrapolate at left end.
             Default to be False.
-
-            r_extra (bool, optional):
+        r_extra
             A optional bool variable indicates that if extrapolate at right end.
             Default to be False.
 
-        Returns:
-            numpy.ndarray:
+        Returns
+        -------
+        numpy.ndarray
             Return design matrix.
         """
         mat = np.vstack(
@@ -686,25 +697,24 @@ class XSpline:
         return mat
 
     def design_dmat(self, x, order, l_extra=False, r_extra=False):
-        r"""Compute the design matrix of spline basis derivatives.
+        """Compute the design matrix of spline basis derivatives.
 
-        Args:
-            x (float | numpy.ndarray):
+        Parameters
+        ----------
+        x
             Scalar or numpy array that store the independent variables.
-
-            order (int):
+        order
             A non-negative integer that indicates the order of differentiation.
-
-            l_extra (bool, optional):
+        l_extra
             A optional bool variable indicates that if extrapolate at left end.
             Default to be False.
-
-            r_extra (bool, optional):
+        r_extra
             A optional bool variable indicates that if extrapolate at right end.
             Default to be False.
 
-        Returns:
-            numpy.ndarray:
+        Returns
+        -------
+        numpy.ndarray
             Return design matrix.
         """
         dmat = np.vstack(
@@ -718,30 +728,28 @@ class XSpline:
         return dmat
 
     def design_imat(self, a, x, order, l_extra=False, r_extra=False):
-        r"""Compute the design matrix of the integrals of the spline bases.
+        """Compute the design matrix of the integrals of the spline bases.
 
-        Args:
-            a (float | numpy.ndarray):
+        Parameters
+        ----------
+        a
             Scalar or numpy array that store the starting point of the
             integration.
-
-            x (float | numpy.ndarray):
+        x
             Scalar or numpy array that store the ending point of the
             integration.
-
-            order (int):
+        order
             A non-negative integer that indicates the order of integration.
-
-            l_extra (bool, optional):
+        l_extra
             A optional bool variable indicates that if extrapolate at left end.
             Default to be False.
-
-            r_extra (bool, optional):
+        r_extra
             A optional bool variable indicates that if extrapolate at right end.
             Default to be False.
 
-        Returns:
-            numpy.ndarray:
+        Returns
+        -------
+        numpy.ndarray
             Return design matrix.
         """
         imat = np.vstack(
@@ -757,8 +765,9 @@ class XSpline:
     def last_dmat(self):
         """Compute highest order of derivative in domain.
 
-        Returns:
-            numpy.ndarray:
+        Returns
+        -------
+        numpy.ndarray
             1D array that contains highest order of derivative for intervals.
         """
         # compute the last dmat for the inner domain
@@ -774,7 +783,52 @@ class XSpline:
 
 
 class NDXSpline:
-    """Multi-dimensional xspline."""
+    """Multi-dimensional xspline.
+
+    Parameters
+    ----------
+    ndim
+        Number of dimension.
+    knots_list
+        List of knots for every dimension.
+    degree_list
+        List of degree for every dimension.
+    l_linear_list
+        List of indicator of if have left linear tail for each dimension.
+    r_linear_list
+        List of indicator of if have right linear tail for each dimension.
+    include_first_basis_list
+        List of indicator of if include the first basis for each dimension.
+
+    Attributes
+    ----------
+    ndim
+        Number of dimension.
+    knots_list
+        List of knots for every dimension.
+    degree_list
+        List of degree for every dimension.
+    l_linear_list
+        List of indicator of if have left linear tail for each dimension.
+    r_linear_list
+        List of indicator of if have right linear tail for each dimension.
+    include_first_basis_list
+        List of indicator of if include the first basis for each dimension.
+    spline_list
+        List of the one dimensional ``XSpline`` for each dimension.
+    num_knots_list
+        Number of knots for each dimension.
+    num_intervals_list
+        Number of intervals for each dimension.
+    num_spline_bases_list
+        Number of spline bases for each dimension.
+    num_knots
+        Total number of knots.
+    num_intervals
+        Total number of intervals.
+    num_spline_bases
+        Total number of spline bases.
+    """
 
     def __init__(
         self,
@@ -785,22 +839,7 @@ class NDXSpline:
         r_linear_list=None,
         include_first_basis_list=True,
     ):
-        """Constructor of ndXSpline class
-
-        Args:
-            ndim (int):
-                Number of dimension.
-            knots_list (list{numpy.ndarray}):
-                List of knots for every dimension.
-            degree_list (list{int}):
-                List of degree for every dimension.
-            l_linear_list (list{bool} | None, optional):
-                List of indicator of if have left linear tail for each
-                dimension.
-            r_linear_list (list{bool} | None, optional):
-                List of indicator of if have right linear tail for each
-                dimension.
-        """
+        """Constructor of ndXSpline class."""
         self.ndim = ndim
         self.knots_list = knots_list
         self.degree_list = degree_list
@@ -838,24 +877,24 @@ class NDXSpline:
     def design_mat(self, x_list, is_grid=True, l_extra_list=None, r_extra_list=None):
         """Design matrix of the spline basis.
 
-        Args:
-            x_list (list{numpy.ndarray}):
-                A list of coordinates for each dimension, they should have the
-                same dimension or come in matrix form.
-            is_grid (bool, optional):
-                If `True` treat the coordinates from `x_list` as the grid points
-                and compute the mesh grid from it, otherwise, treat each group
-                of the coordinates independent.
-            l_extra_list (list{bool} | None, optional):
-                Indicators of if extrapolate in the left side for each
-                dimension.
-            r_extra_list (list{bool} | None, optional):
-                Indicators of if extrapolate in the right side for each
-                dimension.
+        Parameters
+        ----------
+        x_list
+            A list of coordinates for each dimension, they should have the
+            same dimension or come in matrix form.
+        is_grid
+            If `True` treat the coordinates from `x_list` as the grid points
+            and compute the mesh grid from it, otherwise, treat each group
+            of the coordinates independent.
+        l_extra_list
+            Indicators of if extrapolate in the left side for each dimension.
+        r_extra_list
+            Indicators of if extrapolate in the right side for each dimension.
 
-        Returns:
-            numpy.ndarray:
-                Design matrix.
+        Returns
+        -------
+        numpy.ndarray
+            Design matrix.
         """
         l_extra_list = utils.option_to_list(l_extra_list, self.ndim)
         r_extra_list = utils.option_to_list(r_extra_list, self.ndim)
@@ -893,27 +932,27 @@ class NDXSpline:
     ):
         """Design matrix of the derivatives of spline basis.
 
-        Args:
-            x_list (list{numpy.ndarray}):
-                A list of coordinates for each dimension, they should have the
-                same dimension or come in matrix form.
-            n_list (list{int}):
-                A list of integers indicates the order of differentiation for
-                each dimension.
-            is_grid (bool, optional):
-                If `True` treat the coordinates from `x_list` as the grid points
-                and compute the mesh grid from it, otherwise, treat each group
-                of the coordinates independent.
-            l_extra_list (list{bool} | None, optional):
-                Indicators of if extrapolate in the left side for each
-                dimension.
-            r_extra_list (list{bool} | None, optional):
-                Indicators of if extrapolate in the right side for each
-                dimension.
+        Parameters
+        ----------
+        x_list
+            A list of coordinates for each dimension, they should have the
+            same dimension or come in matrix form.
+        n_list
+            A list of integers indicates the order of differentiation for
+            each dimension.
+        is_grid
+            If `True` treat the coordinates from `x_list` as the grid points
+            and compute the mesh grid from it, otherwise, treat each group
+            of the coordinates independent.
+        l_extra_list
+            Indicators of if extrapolate in the left side for each dimension.
+        r_extra_list
+            Indicators of if extrapolate in the right side for each dimension.
 
-        Returns:
-            numpy.ndarray:
-                Differentiation design matrix.
+        Returns
+        -------
+        numpy.ndarray
+            Differentiation design matrix.
         """
         l_extra_list = utils.option_to_list(l_extra_list, self.ndim)
         r_extra_list = utils.option_to_list(r_extra_list, self.ndim)
@@ -952,29 +991,29 @@ class NDXSpline:
     ):
         """Design matrix of the spline basis.
 
-        Args:
-            a_list (list{numpy.ndarray}):
-                Start of integration of coordinates for each dimension.
-            x_list (list{numpy.ndarray}):
-                A list of coordinates for each dimension, they should have the
-                same dimension or come in matrix form.
-            n_list (list{int}):
-                A list of integers indicates the order of integration for
-                each dimension.
-            is_grid (bool, optional):
-                If `True` treat the coordinates from `x_list` as the grid points
-                and compute the mesh grid from it, otherwise, treat each group
-                of the coordinates independent.
-            l_extra_list (list{bool} | None, optional):
-                Indicators of if extrapolate in the left side for each
-                dimension.
-            r_extra_list (list{bool} | None, optional):
-                Indicators of if extrapolate in the right side for each
-                dimension.
+        Parameters
+        ----------
+        a_list
+            Start of integration of coordinates for each dimension.
+        x_list
+            A list of coordinates for each dimension, they should have the
+            same dimension or come in matrix form.
+        n_list
+            A list of integers indicates the order of integration for
+            each dimension.
+        is_grid
+            If `True` treat the coordinates from `x_list` as the grid points
+            and compute the mesh grid from it, otherwise, treat each group
+            of the coordinates independent.
+        l_extra_list
+            Indicators of if extrapolate in the left side for each dimension.
+        r_extra_list
+            Indicators of if extrapolate in the right side for each dimension.
 
-        Returns:
-            numpy.ndarray:
-                Integration design matrix.
+        Returns
+        -------
+        numpy.ndarray
+            Integration design matrix.
         """
         l_extra_list = utils.option_to_list(l_extra_list, self.ndim)
         r_extra_list = utils.option_to_list(r_extra_list, self.ndim)
@@ -1016,9 +1055,10 @@ class NDXSpline:
     def last_dmat(self):
         """Highest order of derivative matrix.
 
-        Returns:
-            numpy.ndarray:
-                Design matrix contain the highest order of derivative.
+        Returns
+        -------
+        numpy.ndarray
+            Design matrix contain the highest order of derivative.
         """
         mat_list = [spline.last_dmat() for spline in self.spline_list]
 

--- a/src/xspline/core.py
+++ b/src/xspline/core.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """
-    core
-    ~~~~
+core
+~~~~
 
-    core module contains main functions and classes.
+core module contains main functions and classes.
 """
+
 import numpy as np
 from . import utils
 
@@ -101,20 +102,18 @@ def bspline_fun(x, knots, degree, idx, l_extra=False, r_extra=False):
         b_effect = bspline_domain(knots, degree, idx)
         y = utils.indicator_f(x, b)
         z = utils.linear_rf(x, b_effect)
-        return y*(z**degree)
+        return y * (z**degree)
 
     if idx == num_splines - 1:
         b_effect = bspline_domain(knots, degree, idx)
         y = utils.indicator_f(x, b, r_close=True)
         z = utils.linear_lf(x, b_effect)
-        return y*(z**degree)
+        return y * (z**degree)
 
-    lf = bspline_fun(x, knots, degree - 1, idx - 1,
-                     l_extra=l_extra, r_extra=r_extra)
+    lf = bspline_fun(x, knots, degree - 1, idx - 1, l_extra=l_extra, r_extra=r_extra)
     lf *= utils.linear_lf(x, bspline_domain(knots, degree - 1, idx - 1))
 
-    rf = bspline_fun(x, knots, degree - 1, idx,
-                     l_extra=l_extra, r_extra=r_extra)
+    rf = bspline_fun(x, knots, degree - 1, idx, l_extra=l_extra, r_extra=r_extra)
     rf *= utils.linear_rf(x, bspline_domain(knots, degree - 1, idx))
 
     return lf + rf
@@ -160,8 +159,7 @@ def bspline_dfun(x, knots, degree, order, idx, l_extra=False, r_extra=False):
         idx = num_splines - 1
 
     if order == 0:
-        return bspline_fun(x, knots, degree, idx,
-                           l_extra=l_extra, r_extra=r_extra)
+        return bspline_fun(x, knots, degree, idx, l_extra=l_extra, r_extra=r_extra)
 
     if order > degree:
         if np.isscalar(x):
@@ -174,22 +172,40 @@ def bspline_dfun(x, knots, degree, order, idx, l_extra=False, r_extra=False):
     else:
         b = bspline_domain(knots, degree - 1, idx - 1)
         d = b[1] - b[0]
-        f = (x - b[0])/d
-        rdf = f*bspline_dfun(x, knots, degree - 1, order, idx - 1,
-                             l_extra=l_extra, r_extra=r_extra)
-        rdf += order*bspline_dfun(x, knots, degree - 1, order - 1, idx - 1,
-                                  l_extra=l_extra, r_extra=r_extra)/d
+        f = (x - b[0]) / d
+        rdf = f * bspline_dfun(
+            x, knots, degree - 1, order, idx - 1, l_extra=l_extra, r_extra=r_extra
+        )
+        rdf += (
+            order
+            * bspline_dfun(
+                x,
+                knots,
+                degree - 1,
+                order - 1,
+                idx - 1,
+                l_extra=l_extra,
+                r_extra=r_extra,
+            )
+            / d
+        )
 
     if idx == num_splines - 1:
         ldf = 0.0
     else:
         b = bspline_domain(knots, degree - 1, idx)
         d = b[0] - b[1]
-        f = (x - b[1])/d
-        ldf = f*bspline_dfun(x, knots, degree - 1, order, idx,
-                             l_extra=l_extra, r_extra=r_extra)
-        ldf += order*bspline_dfun(x, knots, degree - 1, order - 1, idx,
-                                  l_extra=l_extra, r_extra=r_extra)/d
+        f = (x - b[1]) / d
+        ldf = f * bspline_dfun(
+            x, knots, degree - 1, order, idx, l_extra=l_extra, r_extra=r_extra
+        )
+        ldf += (
+            order
+            * bspline_dfun(
+                x, knots, degree - 1, order - 1, idx, l_extra=l_extra, r_extra=r_extra
+            )
+            / d
+        )
 
     return ldf + rdf
 
@@ -237,8 +253,7 @@ def bspline_ifun(a, x, knots, degree, order, idx, l_extra=False, r_extra=False):
         idx = num_splines - 1
 
     if order == 0:
-        return bspline_fun(x, knots, degree, idx,
-                           l_extra=l_extra, r_extra=r_extra)
+        return bspline_fun(x, knots, degree, idx, l_extra=l_extra, r_extra=r_extra)
 
     if degree == 0:
         b = bspline_domain(knots, degree, idx, l_extra=l_extra, r_extra=r_extra)
@@ -250,10 +265,23 @@ def bspline_ifun(a, x, knots, degree, order, idx, l_extra=False, r_extra=False):
         b = bspline_domain(knots, degree - 1, idx - 1)
         d = b[1] - b[0]
         f = (x - b[0]) / d
-        rif = f*bspline_ifun(a, x, knots, degree - 1, order, idx - 1,
-                             l_extra=l_extra, r_extra=r_extra)
-        rif -= order*bspline_ifun(a, x, knots, degree - 1, order + 1, idx - 1,
-                                  l_extra=l_extra, r_extra=r_extra)/d
+        rif = f * bspline_ifun(
+            a, x, knots, degree - 1, order, idx - 1, l_extra=l_extra, r_extra=r_extra
+        )
+        rif -= (
+            order
+            * bspline_ifun(
+                a,
+                x,
+                knots,
+                degree - 1,
+                order + 1,
+                idx - 1,
+                l_extra=l_extra,
+                r_extra=r_extra,
+            )
+            / d
+        )
 
     if idx == num_splines - 1:
         lif = 0.0
@@ -261,24 +289,38 @@ def bspline_ifun(a, x, knots, degree, order, idx, l_extra=False, r_extra=False):
         b = bspline_domain(knots, degree - 1, idx)
         d = b[0] - b[1]
         f = (x - b[1]) / d
-        lif = f*bspline_ifun(a, x, knots, degree - 1, order, idx,
-                             l_extra=l_extra, r_extra=r_extra)
-        lif -= order*bspline_ifun(a, x, knots, degree - 1, order + 1, idx,
-                                  l_extra=l_extra, r_extra=r_extra)/d
+        lif = f * bspline_ifun(
+            a, x, knots, degree - 1, order, idx, l_extra=l_extra, r_extra=r_extra
+        )
+        lif -= (
+            order
+            * bspline_ifun(
+                a,
+                x,
+                knots,
+                degree - 1,
+                order + 1,
+                idx,
+                l_extra=l_extra,
+                r_extra=r_extra,
+            )
+            / d
+        )
 
     return lif + rif
 
 
 class XSpline:
-    """XSpline main class of the package.
-    """
+    """XSpline main class of the package."""
 
-    def __init__(self,
-                 knots,
-                 degree,
-                 l_linear=False,
-                 r_linear=False,
-                 include_first_basis: bool = True):
+    def __init__(
+        self,
+        knots,
+        degree,
+        l_linear=False,
+        r_linear=False,
+        include_first_basis: bool = True,
+    ):
         r"""Constructor of the XSpline class.
 
         knots (numpy.ndarray):
@@ -314,14 +356,15 @@ class XSpline:
         assert isinstance(self.degree, int) and self.degree >= 0
 
         # create inner knots
-        self.inner_knots = self.knots[int_l_linear:
-                                      self.num_knots - int_r_linear]
+        self.inner_knots = self.knots[int_l_linear : self.num_knots - int_r_linear]
         self.lb = self.knots[0]
         self.ub = self.knots[-1]
         self.inner_lb = self.inner_knots[0]
         self.inner_ub = self.inner_knots[-1]
 
-        self.num_spline_bases = self.inner_knots.size - 1 + self.degree - self.basis_start
+        self.num_spline_bases = (
+            self.inner_knots.size - 1 + self.degree - self.basis_start
+        )
 
     def domain(self, idx, l_extra=False, r_extra=False):
         """Return the support of the XSpline.
@@ -343,11 +386,9 @@ class XSpline:
             1D array with two elements represents that left and right end of the
             support of the spline basis.
         """
-        inner_domain = bspline_domain(self.inner_knots,
-                                      self.degree,
-                                      idx,
-                                      l_extra=l_extra,
-                                      r_extra=r_extra)
+        inner_domain = bspline_domain(
+            self.inner_knots, self.degree, idx, l_extra=l_extra, r_extra=r_extra
+        )
         lb = inner_domain[0]
         ub = inner_domain[1]
 
@@ -380,12 +421,9 @@ class XSpline:
             Function values of the corresponding spline bases.
         """
         if not self.l_linear and not self.r_linear:
-            return bspline_fun(x,
-                               self.inner_knots,
-                               self.degree,
-                               idx,
-                               l_extra=l_extra,
-                               r_extra=r_extra)
+            return bspline_fun(
+                x, self.inner_knots, self.degree, idx, l_extra=l_extra, r_extra=r_extra
+            )
 
         x_is_scalar = np.isscalar(x)
         if x_is_scalar:
@@ -396,40 +434,38 @@ class XSpline:
 
         if self.l_linear:
             l_idx = (x < self.inner_lb) & ((x >= self.lb) | l_extra)
-            m_idx &= (x >= self.inner_lb)
+            m_idx &= x >= self.inner_lb
 
-            inner_lb_yun = bspline_fun(self.inner_lb,
-                                       self.inner_knots,
-                                       self.degree,
-                                       idx)
-            inner_lb_dfun = bspline_dfun(self.inner_lb,
-                                         self.inner_knots,
-                                         self.degree,
-                                         1, idx)
+            inner_lb_yun = bspline_fun(
+                self.inner_lb, self.inner_knots, self.degree, idx
+            )
+            inner_lb_dfun = bspline_dfun(
+                self.inner_lb, self.inner_knots, self.degree, 1, idx
+            )
 
             f[l_idx] = inner_lb_yun + inner_lb_dfun * (x[l_idx] - self.inner_lb)
 
         if self.r_linear:
             u_idx = (x > self.inner_ub) & ((x <= self.ub) | r_extra)
-            m_idx &= (x <= self.inner_ub)
+            m_idx &= x <= self.inner_ub
 
-            inner_ub_yun = bspline_fun(self.inner_ub,
-                                       self.inner_knots,
-                                       self.degree,
-                                       idx)
-            inner_ub_dfun = bspline_dfun(self.inner_ub,
-                                         self.inner_knots,
-                                         self.degree,
-                                         1, idx)
+            inner_ub_yun = bspline_fun(
+                self.inner_ub, self.inner_knots, self.degree, idx
+            )
+            inner_ub_dfun = bspline_dfun(
+                self.inner_ub, self.inner_knots, self.degree, 1, idx
+            )
 
             f[u_idx] = inner_ub_yun + inner_ub_dfun * (x[u_idx] - self.inner_ub)
 
-        f[m_idx] = bspline_fun(x[m_idx],
-                               self.inner_knots,
-                               self.degree,
-                               idx,
-                               l_extra=l_extra,
-                               r_extra=r_extra)
+        f[m_idx] = bspline_fun(
+            x[m_idx],
+            self.inner_knots,
+            self.degree,
+            idx,
+            l_extra=l_extra,
+            r_extra=r_extra,
+        )
 
         if x_is_scalar:
             return f[0]
@@ -466,13 +502,9 @@ class XSpline:
             return self.fun(x, idx, l_extra=l_extra, r_extra=r_extra)
 
         if (not self.l_linear) and (not self.r_linear):
-            return bspline_dfun(x,
-                                self.knots,
-                                self.degree,
-                                order,
-                                idx,
-                                l_extra=l_extra,
-                                r_extra=r_extra)
+            return bspline_dfun(
+                x, self.knots, self.degree, order, idx, l_extra=l_extra, r_extra=r_extra
+            )
 
         x_is_scalar = np.isscalar(x)
         if x_is_scalar:
@@ -483,33 +515,33 @@ class XSpline:
 
         if self.l_linear:
             l_idx = (x < self.inner_lb) & ((x >= self.lb) | l_extra)
-            m_idx &= (x >= self.inner_lb)
+            m_idx &= x >= self.inner_lb
 
             if order == 1:
-                inner_lb_dy = bspline_dfun(self.inner_lb,
-                                           self.inner_knots,
-                                           self.degree,
-                                           order, idx)
+                inner_lb_dy = bspline_dfun(
+                    self.inner_lb, self.inner_knots, self.degree, order, idx
+                )
                 dy[l_idx] = np.repeat(inner_lb_dy, np.sum(l_idx))
 
         if self.r_linear:
             u_idx = (x > self.inner_ub) & ((x <= self.ub) | r_extra)
-            m_idx &= (x <= self.inner_ub)
+            m_idx &= x <= self.inner_ub
 
             if order == 1:
-                inner_ub_dy = bspline_dfun(self.inner_ub,
-                                           self.inner_knots,
-                                           self.degree,
-                                           order, idx)
+                inner_ub_dy = bspline_dfun(
+                    self.inner_ub, self.inner_knots, self.degree, order, idx
+                )
                 dy[u_idx] = np.repeat(inner_ub_dy, np.sum(u_idx))
 
-        dy[m_idx] = bspline_dfun(x[m_idx],
-                                 self.inner_knots,
-                                 self.degree,
-                                 order,
-                                 idx,
-                                 l_extra=l_extra,
-                                 r_extra=r_extra)
+        dy[m_idx] = bspline_dfun(
+            x[m_idx],
+            self.inner_knots,
+            self.degree,
+            order,
+            idx,
+            l_extra=l_extra,
+            r_extra=r_extra,
+        )
 
         if x_is_scalar:
             return dy[0]
@@ -551,49 +583,43 @@ class XSpline:
             return self.fun(x, idx, l_extra=l_extra, r_extra=r_extra)
 
         if (not self.l_linear) and (not self.r_linear):
-            return bspline_ifun(a, x,
-                                self.knots,
-                                self.degree,
-                                order,
-                                idx,
-                                l_extra=l_extra,
-                                r_extra=r_extra)
+            return bspline_ifun(
+                a,
+                x,
+                self.knots,
+                self.degree,
+                order,
+                idx,
+                l_extra=l_extra,
+                r_extra=r_extra,
+            )
         # verify the inputs
         assert np.all(a <= x)
 
         # function and derivative values at inner lb and inner rb
-        inner_lb_y = bspline_fun(self.inner_lb,
-                                 self.inner_knots,
-                                 self.degree,
-                                 idx)
-        inner_ub_y = bspline_fun(self.inner_ub,
-                                 self.inner_knots,
-                                 self.degree,
-                                 idx)
-        inner_lb_dy = bspline_dfun(self.inner_lb,
-                                   self.inner_knots,
-                                   self.degree,
-                                   1, idx)
-        inner_ub_dy = bspline_dfun(self.inner_ub,
-                                   self.inner_knots,
-                                   self.degree,
-                                   1, idx)
+        inner_lb_y = bspline_fun(self.inner_lb, self.inner_knots, self.degree, idx)
+        inner_ub_y = bspline_fun(self.inner_ub, self.inner_knots, self.degree, idx)
+        inner_lb_dy = bspline_dfun(self.inner_lb, self.inner_knots, self.degree, 1, idx)
+        inner_ub_dy = bspline_dfun(self.inner_ub, self.inner_knots, self.degree, 1, idx)
 
         # there are in total 5 pieces functions
         def l_piece(a, x, order):
-            return utils.linear_if(a, x, order,
-                                   self.inner_lb, inner_lb_y, inner_lb_dy)
+            return utils.linear_if(a, x, order, self.inner_lb, inner_lb_y, inner_lb_dy)
 
         def m_piece(a, x, order):
-            return bspline_ifun(a, x,
-                                self.inner_knots,
-                                self.degree,
-                                order, idx,
-                                l_extra=l_extra, r_extra=r_extra)
+            return bspline_ifun(
+                a,
+                x,
+                self.inner_knots,
+                self.degree,
+                order,
+                idx,
+                l_extra=l_extra,
+                r_extra=r_extra,
+            )
 
         def r_piece(a, x, order):
-            return utils.linear_if(a, x, order,
-                                   self.inner_ub, inner_ub_y, inner_ub_dy)
+            return utils.linear_if(a, x, order, self.inner_ub, inner_ub_y, inner_ub_dy)
 
         def zero_piece(a, x, order):
             if np.isscalar(a) and np.isscalar(x):
@@ -649,10 +675,14 @@ class XSpline:
             numpy.ndarray:
             Return design matrix.
         """
-        mat = np.vstack([
-            self.fun(x, idx, l_extra=l_extra, r_extra=r_extra)
-            for idx in range(self.basis_start, self.num_spline_bases + self.basis_start)
-        ]).T
+        mat = np.vstack(
+            [
+                self.fun(x, idx, l_extra=l_extra, r_extra=r_extra)
+                for idx in range(
+                    self.basis_start, self.num_spline_bases + self.basis_start
+                )
+            ]
+        ).T
         return mat
 
     def design_dmat(self, x, order, l_extra=False, r_extra=False):
@@ -677,10 +707,14 @@ class XSpline:
             numpy.ndarray:
             Return design matrix.
         """
-        dmat = np.vstack([
-            self.dfun(x, order, idx, l_extra=l_extra, r_extra=r_extra)
-            for idx in range(self.basis_start, self.num_spline_bases + self.basis_start)
-        ]).T
+        dmat = np.vstack(
+            [
+                self.dfun(x, order, idx, l_extra=l_extra, r_extra=r_extra)
+                for idx in range(
+                    self.basis_start, self.num_spline_bases + self.basis_start
+                )
+            ]
+        ).T
         return dmat
 
     def design_imat(self, a, x, order, l_extra=False, r_extra=False):
@@ -710,10 +744,14 @@ class XSpline:
             numpy.ndarray:
             Return design matrix.
         """
-        imat = np.vstack([
-            self.ifun(a, x, order, idx, l_extra=l_extra, r_extra=r_extra)
-            for idx in range(self.basis_start, self.num_spline_bases + self.basis_start)
-        ]).T
+        imat = np.vstack(
+            [
+                self.ifun(a, x, order, idx, l_extra=l_extra, r_extra=r_extra)
+                for idx in range(
+                    self.basis_start, self.num_spline_bases + self.basis_start
+                )
+            ]
+        ).T
         return imat
 
     def last_dmat(self):
@@ -727,24 +765,26 @@ class XSpline:
         dmat = self.design_dmat(self.inner_knots[:-1], self.degree)
 
         if self.l_linear:
-            dmat = np.vstack((self.design_dmat(np.array([self.inner_lb]), 1),
-                              dmat))
+            dmat = np.vstack((self.design_dmat(np.array([self.inner_lb]), 1), dmat))
 
         if self.r_linear:
-            dmat = np.vstack((dmat,
-                              self.design_dmat(np.array([self.inner_ub]), 1)))
+            dmat = np.vstack((dmat, self.design_dmat(np.array([self.inner_ub]), 1)))
 
         return dmat
 
 
 class NDXSpline:
-    """Multi-dimensional xspline.
-    """
+    """Multi-dimensional xspline."""
 
-    def __init__(self, ndim, knots_list, degree_list,
-                 l_linear_list=None,
-                 r_linear_list=None,
-                 include_first_basis_list=True):
+    def __init__(
+        self,
+        ndim,
+        knots_list,
+        degree_list,
+        l_linear_list=None,
+        r_linear_list=None,
+        include_first_basis_list=True,
+    ):
         """Constructor of ndXSpline class
 
         Args:
@@ -766,31 +806,36 @@ class NDXSpline:
         self.degree_list = degree_list
         self.l_linear_list = utils.option_to_list(l_linear_list, self.ndim)
         self.r_linear_list = utils.option_to_list(r_linear_list, self.ndim)
-        self.include_first_basis_list = utils.option_to_list(include_first_basis_list, self.ndim)
+        self.include_first_basis_list = utils.option_to_list(
+            include_first_basis_list, self.ndim
+        )
 
         self.spline_list = [
-            XSpline(self.knots_list[i], self.degree_list[i],
-                    l_linear=self.l_linear_list[i],
-                    r_linear=self.r_linear_list[i],
-                    include_first_basis=self.include_first_basis_list[i])
+            XSpline(
+                self.knots_list[i],
+                self.degree_list[i],
+                l_linear=self.l_linear_list[i],
+                r_linear=self.r_linear_list[i],
+                include_first_basis=self.include_first_basis_list[i],
+            )
             for i in range(self.ndim)
         ]
 
-        self.num_knots_list = np.array([
-            spline.num_knots for spline in self.spline_list])
-        self.num_intervals_list = np.array([
-            spline.num_intervals for spline in self.spline_list])
-        self.num_spline_bases_list = np.array([
-            spline.num_spline_bases for spline in self.spline_list])
+        self.num_knots_list = np.array(
+            [spline.num_knots for spline in self.spline_list]
+        )
+        self.num_intervals_list = np.array(
+            [spline.num_intervals for spline in self.spline_list]
+        )
+        self.num_spline_bases_list = np.array(
+            [spline.num_spline_bases for spline in self.spline_list]
+        )
 
         self.num_knots = self.num_knots_list.prod()
         self.num_intervals = self.num_intervals_list.prod()
         self.num_spline_bases = self.num_spline_bases_list.prod()
 
-    def design_mat(self, x_list,
-                   is_grid=True,
-                   l_extra_list=None,
-                   r_extra_list=None):
+    def design_mat(self, x_list, is_grid=True, l_extra_list=None, r_extra_list=None):
         """Design matrix of the spline basis.
 
         Args:
@@ -819,35 +864,33 @@ class NDXSpline:
         assert len(l_extra_list) == self.ndim
         assert len(r_extra_list) == self.ndim
 
-        mat_list = [spline.design_mat(x_list[i],
-                                      l_extra=l_extra_list[i],
-                                      r_extra=r_extra_list[i])
-                    for i, spline in enumerate(self.spline_list)]
+        mat_list = [
+            spline.design_mat(
+                x_list[i], l_extra=l_extra_list[i], r_extra=r_extra_list[i]
+            )
+            for i, spline in enumerate(self.spline_list)
+        ]
 
         if is_grid:
             mat = []
             for i in range(self.num_spline_bases):
                 index_list = utils.order_to_index(i, self.num_spline_bases_list)
-                bases_list = [mat_list[j][:, index_list[j]]
-                              for j in range(self.ndim)]
+                bases_list = [mat_list[j][:, index_list[j]] for j in range(self.ndim)]
                 mat.append(utils.outer_flatten(*bases_list))
         else:
             num_points = x_list[0].size
-            assert np.all([x_list[i].size == num_points
-                           for i in range(self.ndim)])
+            assert np.all([x_list[i].size == num_points for i in range(self.ndim)])
             mat = []
             for i in range(self.num_spline_bases):
                 index_list = utils.order_to_index(i, self.num_spline_bases_list)
-                bases_list = [mat_list[j][:, index_list[j]]
-                              for j in range(self.ndim)]
+                bases_list = [mat_list[j][:, index_list[j]] for j in range(self.ndim)]
                 mat.append(np.prod(bases_list, axis=0))
 
         return np.ascontiguousarray(np.vstack(mat).T)
 
-    def design_dmat(self, x_list, n_list,
-                    is_grid=True,
-                    l_extra_list=None,
-                    r_extra_list=None):
+    def design_dmat(
+        self, x_list, n_list, is_grid=True, l_extra_list=None, r_extra_list=None
+    ):
         """Design matrix of the derivatives of spline basis.
 
         Args:
@@ -880,35 +923,33 @@ class NDXSpline:
         assert len(l_extra_list) == self.ndim
         assert len(r_extra_list) == self.ndim
 
-        dmat_list = [spline.design_dmat(x_list[i], n_list[i],
-                                        l_extra=l_extra_list[i],
-                                        r_extra=r_extra_list[i])
-                     for i, spline in enumerate(self.spline_list)]
+        dmat_list = [
+            spline.design_dmat(
+                x_list[i], n_list[i], l_extra=l_extra_list[i], r_extra=r_extra_list[i]
+            )
+            for i, spline in enumerate(self.spline_list)
+        ]
 
         if is_grid:
             dmat = []
             for i in range(self.num_spline_bases):
                 index_list = utils.order_to_index(i, self.num_spline_bases_list)
-                bases_list = [dmat_list[j][:, index_list[j]]
-                              for j in range(self.ndim)]
+                bases_list = [dmat_list[j][:, index_list[j]] for j in range(self.ndim)]
                 dmat.append(utils.outer_flatten(*bases_list))
         else:
             num_points = x_list[0].size
-            assert np.all([x_list[i].size == num_points
-                           for i in range(self.ndim)])
+            assert np.all([x_list[i].size == num_points for i in range(self.ndim)])
             dmat = []
             for i in range(self.num_spline_bases):
                 index_list = utils.order_to_index(i, self.num_spline_bases_list)
-                bases_list = [dmat_list[j][:, index_list[j]]
-                              for j in range(self.ndim)]
+                bases_list = [dmat_list[j][:, index_list[j]] for j in range(self.ndim)]
                 dmat.append(np.prod(bases_list, axis=0))
 
         return np.ascontiguousarray(np.vstack(dmat).T)
 
-    def design_imat(self, a_list, x_list, n_list,
-                    is_grid=True,
-                    l_extra_list=None,
-                    r_extra_list=None):
+    def design_imat(
+        self, a_list, x_list, n_list, is_grid=True, l_extra_list=None, r_extra_list=None
+    ):
         """Design matrix of the spline basis.
 
         Args:
@@ -944,27 +985,30 @@ class NDXSpline:
         assert len(l_extra_list) == self.ndim
         assert len(r_extra_list) == self.ndim
 
-        imat_list = [spline.design_imat(a_list[i], x_list[i], n_list[i],
-                                        l_extra=l_extra_list[i],
-                                        r_extra=r_extra_list[i])
-                     for i, spline in enumerate(self.spline_list)]
+        imat_list = [
+            spline.design_imat(
+                a_list[i],
+                x_list[i],
+                n_list[i],
+                l_extra=l_extra_list[i],
+                r_extra=r_extra_list[i],
+            )
+            for i, spline in enumerate(self.spline_list)
+        ]
 
         if is_grid:
             imat = []
             for i in range(self.num_spline_bases):
                 index_list = utils.order_to_index(i, self.num_spline_bases_list)
-                bases_list = [imat_list[j][:, index_list[j]]
-                              for j in range(self.ndim)]
+                bases_list = [imat_list[j][:, index_list[j]] for j in range(self.ndim)]
                 imat.append(utils.outer_flatten(*bases_list))
         else:
             num_points = x_list[0].size
-            assert np.all([x_list[i].size == num_points
-                           for i in range(self.ndim)])
+            assert np.all([x_list[i].size == num_points for i in range(self.ndim)])
             imat = []
             for i in range(self.num_spline_bases):
                 index_list = utils.order_to_index(i, self.num_spline_bases_list)
-                bases_list = [imat_list[j][:, index_list[j]]
-                              for j in range(self.ndim)]
+                bases_list = [imat_list[j][:, index_list[j]] for j in range(self.ndim)]
                 imat.append(np.prod(bases_list, axis=0))
 
         return np.ascontiguousarray(np.vstack(imat).T)
@@ -981,8 +1025,7 @@ class NDXSpline:
         mat = []
         for i in range(self.num_spline_bases):
             index_list = utils.order_to_index(i, self.num_spline_bases_list)
-            bases_list = [mat_list[j][:, index_list[j]]
-                          for j in range(self.ndim)]
+            bases_list = [mat_list[j][:, index_list[j]] for j in range(self.ndim)]
             mat.append(utils.outer_flatten(*bases_list))
 
         return np.ascontiguousarray(np.vstack(mat).T)

--- a/src/xspline/core.py
+++ b/src/xspline/core.py
@@ -7,6 +7,7 @@ core module contains main functions and classes.
 """
 
 import numpy as np
+
 from . import utils
 
 

--- a/src/xspline/core.py
+++ b/src/xspline/core.py
@@ -1,11 +1,3 @@
-# -*- coding: utf-8 -*-
-"""
-core
-~~~~
-
-core module contains main functions and classes.
-"""
-
 import numpy as np
 
 from . import utils

--- a/src/xspline/utils.py
+++ b/src/xspline/utils.py
@@ -1,4 +1,3 @@
-# utility functions for the bsplinex class
 import functools
 import math
 

--- a/src/xspline/utils.py
+++ b/src/xspline/utils.py
@@ -5,24 +5,23 @@ import numpy as np
 
 
 def indicator_f(x, b, l_close=True, r_close=False):
-    r"""Indicator function for provided interval.
+    """Indicator function for provided interval.
 
-    Args:
-        x (float | numpy.ndarray):
+    Parameters
+    ----------
+    x
         Float scalar or numpy array store the variable(s).
-
-        b (numpy.ndarray):
+    b
         1D array with 2 elements represent the left and right end of the
         interval.
-
-        l_close (bool | True, optional):
+    l_close
         Bool variable indicate that if include the left end of the interval.
-
-        r_close (bool | False, optional):
+    r_close
         Bool variable indicate that if include the right end of the interval.
 
-    Returns:
-        float | numpy.ndarray:
+    Returns
+    -------
+    float | numpy.ndarray
         Return function value(s) at ``x``. The result has the same shape with
         ``x``. 0 in the result indicate corresponding element in ``x`` is not in
         the interval and 1 means the it is in the interval.
@@ -44,26 +43,25 @@ def indicator_f(x, b, l_close=True, r_close=False):
 
 
 def linear_f(x, z, fz, dfz):
-    r"""Linear function construct by reference point(s).
+    """Linear function construct by reference point(s).
 
-    Args:
-        x (float | numpy.ndarray):
+    Parameters
+    ----------
+    x
         Float scalar or numpy array store the variable(s).
-
-        z (float | numpy.ndarray):
+    z
         Float scalar or numpy array store the reference point(s). When ``x`` is
         ``np.ndarray``, ``z`` has to have the same shape with ``x``.
-
-        fz (float | numpy.ndarray):
+    fz
         Float scalar or numpy array store the function value(s) at ``z``. Same
         requirements with ``z``.
-
-        dfz (float | numpy.ndarray):
+    dfz
         Float scalar or numpy array store the function derivative(s) at ``z``.
         Same requirements with ``z``.
 
-    Returns:
-        float | numpy.ndarray:
+    Returns
+    -------
+    float | numpy.ndarray
         Return function value(s) at ``x`` with linear function constructed at
         base point(s) ``z``. The result has the same shape with ``x`` when
         ``z`` is scalar or same shape with ``z`` when ``x`` is scalar.
@@ -72,19 +70,20 @@ def linear_f(x, z, fz, dfz):
 
 
 def linear_lf(x, b):
-    r"""Linear function constructed by linearly interpolate 0 and 1 from left
+    """Linear function constructed by linearly interpolate 0 and 1 from left
     end point to right end point.
 
-    Args:
-        x (float | numpy.ndarray):
+    Parameters
+    ----------
+    x
         Float scalar or numpy array that store the variable(s).
-
-        b (numpy.ndarray):
+    b
         1D array with 2 elements represent the left and right end of the
         interval.
 
-    Returns:
-        float | numpy.ndarray:
+    Returns
+    -------
+    float | numpy.ndarray
         Return function value(s) at ``x``. The result has the same shape with
         ``x``.
     """
@@ -92,19 +91,20 @@ def linear_lf(x, b):
 
 
 def linear_rf(x, b):
-    r"""Linear function constructed by linearly interpolate 0 and 1 from right
+    """Linear function constructed by linearly interpolate 0 and 1 from right
     end point to left end point.
 
-    Args:
-        x (float | numpy.ndarray):
+    Parameters
+    ----------
+    x
         Float scalar or numpy array that store the variable(s).
-
-        b (numpy.ndarray):
+    b
         1D array with 2 elements represent the left and right end of the
         interval.
 
-    Returns:
-        float | numpy.ndarray:
+    Returns
+    -------
+    float | numpy.ndarray
         Return function value(s) at ``x``. The result has the same shape with
         ``x``.
     """
@@ -112,26 +112,25 @@ def linear_rf(x, b):
 
 
 def constant_if(a, x, order, c):
-    r"""Integration of constant function.
+    """Integration of constant function.
 
-    Args:
-        a (float | numpy.ndarray):
+    Parameters
+    ----------
+    a
         Starting point(s) of the integration. If both ``a`` and ``x`` are
         ``np.ndarray``, they should have the same shape.
-
-        x (float | numpy.ndarray):
+    x
         Ending point(s) of the integration. If both ``a`` and ``x`` are
         ``np.ndarray``, they should have the same shape.
-
-        order (int):
+    order
         Non-negative integer number indicate the order of integration. In other
         words, how many time(s) we integrate.
-
-        c (float):
+    c
         Constant function value.
 
-    Returns:
-        float | numpy.ndarray:
+    Returns
+    -------
+    float | numpy.ndarray
         Integration value(s) of the constant function.
     """
     # determine the result size
@@ -160,35 +159,32 @@ def constant_if(a, x, order, c):
 
 
 def linear_if(a, x, order, z, fz, dfz):
-    r"""Integrate linear function constructed by the reference point(s).
+    """Integrate linear function constructed by the reference point(s).
 
-    Args:
-        a (float | numpy.ndarray):
+    Parameters
+    ----------
+    a
         Starting point(s) of the integration. If both ``a`` and ``x`` are
         ``np.ndarray``, they should have the same shape.
-
-        x (float | numpy.ndarray):
+    x
         Ending point(s) of the integration. If both ``a`` and ``x`` are
         ``np.ndarray``, they should have the same shape.
-
-        order (int):
+    order
         Non-negative integer number indicate the order of integration. In other
         words, how many time(s) we integrate.
-
-        z (float | numpy.ndarray):
+    z
         Float scalar or numpy array store the reference point(s). When ``x`` is
         ``np.ndarray``, ``z`` has to have the same shape with ``x``.
-
-        fz (float | numpy.ndarray):
+    fz
         Float scalar or numpy array store the function value(s) at ``z``. Same
         requirements with ``z``.
-
-        dfz (float | numpy.ndarray):
+    dfz
         Float scalar or numpy array store the function derivative(s) at ``z``.
         Same requirements with ``z``.
 
-    Returns:
-        float | numpy.ndarray:
+    Returns
+    -------
+    float | numpy.ndarray
         Integration value(s) of the constant function.
     """
     fa = fz + dfz * (a - z)
@@ -200,32 +196,30 @@ def linear_if(a, x, order, z, fz, dfz):
 
 
 def integrate_across_pieces(a, x, order, funcs, knots):
-    r"""Integrate Across piecewise functions.
+    """Integrate Across piecewise functions.
 
-    Args:
-        a (float | numpy.ndarray):
+    Parameters
+    ----------
+    a
         Starting point(s) of the integration. If both ``a`` and ``x`` are
         ``np.ndarray``, they should have the same shape. ``a`` has to be less
         than ``knots[0]``.
-
-        x (float | numpy.ndarray):
+    x
         Ending point(s) of the integration. If both ``a`` and ``x`` are
         ``np.ndarray``, they should have the same shape. ``x`` has to be greater
         than ``knots[-1]``.
-
-        order (int):
+    order
         Non-negative integer number indicate the order of integration. In other
         words, how many time(s) we integrate.
-
-        funcs (list):
+    funcs
         List of functions defined on pieces of domain.
-
-        knots (numpy.ndarray):
+    knots
         1D numpy array contains all the breaking points for the piecewise
         functions.
 
-    Returns:
-        float | numpy.ndarray:
+    Returns
+    -------
+    float | numpy.ndarray
         Integration value(s) of the constant function.
     """
     assert len(funcs) == len(knots) + 1
@@ -250,30 +244,28 @@ def integrate_across_pieces(a, x, order, funcs, knots):
 
 
 def pieces_if(a, x, order, funcs, knots):
-    r"""Integrate pieces of the functions.
+    """Integrate pieces of the functions.
 
-    Args:
-        a (float | numpy.ndarray):
+    Parameters
+    ----------
+    a
         Starting point(s) of the integration. If both ``a`` and ``x`` are
         ``np.ndarray``, they should have the same shape.
-
-        x (float | numpy.ndarray):
+    x
         Ending point(s) of the integration. If both ``a`` and ``x`` are
         ``np.ndarray``, they should have the same shape.
-
-        order (int):
+    order
         Non-negative integer number indicate the order of integration. In other
         words, how many time(s) we integrate.
-
-        funcs (list):
+    funcs
         List of functions defined on pieces of domain.
-
-        knots (numpy.ndarray):
+    knots
         1D numpy array contains all the breaking points for the piecewise
         functions.
 
-    Returns:
-        float | numpy.ndarray:
+    Returns
+    -------
+    float | numpy.ndarray
         Integration value(s) of the constant function.
     """
     # verify the input
@@ -324,33 +316,30 @@ def pieces_if(a, x, order, funcs, knots):
 
 
 def indicator_if(a, x, order, b, l_close=True, r_close=False):
-    r"""Integrate indicator function.
+    """Integrate indicator function.
 
-    Args:
-        a (float | numpy.ndarray):
+    Parameters
+    ----------
+    a
         Starting point(s) of the integration. If both ``a`` and ``x`` are
         ``np.ndarray``, they should have the same shape.
-
-        x (float | numpy.ndarray):
+    x
         Ending point(s) of the integration. If both ``a`` and ``x`` are
         ``np.ndarray``, they should have the same shape.
-
-        order (int):
+    order
         Non-negative integer number indicate the order of integration. In other
         words, how many time(s) we integrate.
-
-        b (numpy.ndarray):
+    b
         1D array with 2 elements represent the left and right end of the
         interval.
-
-        l_close (bool | True, optional):
+    l_close
         Bool variable indicate that if include the left end of the interval.
-
-        r_close (bool | False, optional):
+    r_close
         Bool variable indicate that if include the right end of the interval.
 
-    Returns:
-        float | numpy.ndarray:
+    Returns
+    -------
+    float | numpy.ndarray
         Integration value(s) of the constant function.
     """
     if order == 0:
@@ -370,15 +359,17 @@ def indicator_if(a, x, order, b, l_close=True, r_close=False):
 
 
 def seq_diff_mat(size):
-    r"""Compute sequencial difference matrix.
+    """Compute sequencial difference matrix.
 
-    Args:
-        size (int):
+    Parameters
+    ----------
+    size
         Positive integer that indicate the number of columns of the matrix.
         Number of rows will be 1 less than number of columns.
 
-    Returns:
-        ndarray:
+    Returns
+    -------
+    numpy.ndarray
         A matrix consist of one and minus one.
     """
     assert isinstance(size, int) and size >= 2
@@ -394,18 +385,19 @@ def seq_diff_mat(size):
 
 
 def order_to_index(order, shape):
-    r"""Compute the index of the element in a high dimensional array provided
+    """Compute the index of the element in a high dimensional array provided
     the order of the element.
 
-    Args:
-        order: int
+    Parameters
+    ----------
+    order
         Non-negative integer present the order of the element.
-
-        shape: tuple
+    shape
         Shape tuple of the high dimensional array.
 
-    Returns:
-        tuple:
+    Returns
+    -------
+    tuple
         The index element in the array.
     """
     assert hasattr(shape, "__iter__")
@@ -425,17 +417,18 @@ def order_to_index(order, shape):
 
 
 def option_to_list(opt, size):
-    r"""Convert default option to list of options.
+    """Convert default option to list of options.
 
-    Args:
-        opt (bool | None):
+    Parameters
+    ----------
+    opt
         A single option in the form of bool or None.
-
-        size (int):
+    size
         Positive integer indicate the size of the option list.
 
-    Returns:
-        list:
+    Returns
+    -------
+    list
         Option list consist of bool elements.
     """
     assert isinstance(size, int)
@@ -447,14 +440,16 @@ def option_to_list(opt, size):
 
 
 def outer_flatten(*args):
-    r"""Outer product of multiple vectors and then flatten the result.
+    """Outer product of multiple vectors and then flatten the result.
 
-    Args:
-        args (list | tuple):
+    Parameters
+    ----------
+    args
         A list or tuple of 1D numpy arrays.
 
-    Return:
-        numpy.ndarray:
+    Returns
+    -------
+    numpy.ndarray
         1D numpy array that store the flattened outer product.
     """
     return functools.reduce(np.multiply.outer, args).ravel()

--- a/src/xspline/utils.py
+++ b/src/xspline/utils.py
@@ -1,6 +1,7 @@
 # utility functions for the bsplinex class
 import functools
 import math
+
 import numpy as np
 
 

--- a/src/xspline/utils.py
+++ b/src/xspline/utils.py
@@ -28,14 +28,14 @@ def indicator_f(x, b, l_close=True, r_close=False):
         the interval and 1 means the it is in the interval.
     """
     if l_close:
-        lb = (x >= b[0])
+        lb = x >= b[0]
     else:
-        lb = (x > b[0])
+        lb = x > b[0]
 
     if r_close:
-        rb = (x <= b[1])
+        rb = x <= b[1]
     else:
-        rb = (x < b[1])
+        rb = x < b[1]
 
     if np.isscalar(x):
         return float(lb & rb)
@@ -68,7 +68,7 @@ def linear_f(x, z, fz, dfz):
         base point(s) ``z``. The result has the same shape with ``x`` when
         ``z`` is scalar or same shape with ``z`` when ``x`` is scalar.
     """
-    return fz + dfz*(x - z)
+    return fz + dfz * (x - z)
 
 
 def linear_lf(x, b):
@@ -88,7 +88,7 @@ def linear_lf(x, b):
         Return function value(s) at ``x``. The result has the same shape with
         ``x``.
     """
-    return (x - b[0])/(b[1] - b[0])
+    return (x - b[0]) / (b[1] - b[0])
 
 
 def linear_rf(x, b):
@@ -108,7 +108,7 @@ def linear_rf(x, b):
         Return function value(s) at ``x``. The result has the same shape with
         ``x``.
     """
-    return (x - b[1])/(b[0] - b[1])
+    return (x - b[1]) / (b[0] - b[1])
 
 
 def constant_if(a, x, order, c):
@@ -156,7 +156,7 @@ def constant_if(a, x, order, c):
         else:
             return 0.0
 
-    return c*(x - a)**order/math.factorial(order)
+    return c * (x - a) ** order / math.factorial(order)
 
 
 def linear_if(a, x, order, z, fz, dfz):
@@ -191,11 +191,12 @@ def linear_if(a, x, order, z, fz, dfz):
         float | numpy.ndarray:
         Integration value(s) of the constant function.
     """
-    fa = fz + dfz*(a - z)
+    fa = fz + dfz * (a - z)
     dfa = dfz
 
-    return dfa*(x - a)**(order + 1)/math.factorial(order + 1) + \
-        fa*(x - a)**order/math.factorial(order)
+    return dfa * (x - a) ** (order + 1) / math.factorial(order + 1) + fa * (
+        x - a
+    ) ** order / math.factorial(order)
 
 
 def integrate_across_pieces(a, x, order, funcs, knots):
@@ -231,7 +232,9 @@ def integrate_across_pieces(a, x, order, funcs, knots):
     if len(funcs) == 1:
         return funcs[0](a, x, order)
     else:
-        assert np.all(a < knots[0]) and np.all(x > knots[-1]), f"{a} should be in [{knots[0]}, {knots[-1]}]."
+        assert np.all(a < knots[0]) and np.all(x > knots[-1]), (
+            f"{a} should be in [{knots[0]}, {knots[-1]}]."
+        )
 
     if np.isscalar(a):
         b = knots[0]
@@ -241,7 +244,7 @@ def integrate_across_pieces(a, x, order, funcs, knots):
     val = integrate_across_pieces(b, x, order, funcs[1:], knots[1:])
 
     for j in range(order):
-        val += funcs[0](a, b, order - j)*(x - b)**j / math.factorial(j)
+        val += funcs[0](a, b, order - j) * (x - b) ** j / math.factorial(j)
 
     return val
 
@@ -293,26 +296,26 @@ def pieces_if(a, x, order, funcs, knots):
     num_knots = len(knots)
 
     # different cases
-    a_ind = [a < knots[0]] +\
-            [(a >= knots[i]) & (a < knots[i + 1])
-             for i in range(num_knots - 1)] +\
-            [a >= knots[-1]]
+    a_ind = (
+        [a < knots[0]]
+        + [(a >= knots[i]) & (a < knots[i + 1]) for i in range(num_knots - 1)]
+        + [a >= knots[-1]]
+    )
 
-    x_ind = [x <= knots[0]] +\
-            [(x > knots[i]) & (x <= knots[i + 1])
-             for i in range(num_knots - 1)] +\
-            [x > knots[-1]]
+    x_ind = (
+        [x <= knots[0]]
+        + [(x > knots[i]) & (x <= knots[i + 1]) for i in range(num_knots - 1)]
+        + [x > knots[-1]]
+    )
 
     int_f = np.zeros(a.size)
     for ia in range(len(funcs)):
         for ix in range(ia, len(funcs)):
             case_id = a_ind[ia] & x_ind[ix]
             if np.any(case_id):
-                int_f[case_id] = integrate_across_pieces(a[case_id],
-                                                         x[case_id],
-                                                         order,
-                                                         funcs[ia:ix + 1],
-                                                         knots[ia:ix])
+                int_f[case_id] = integrate_across_pieces(
+                    a[case_id], x[case_id], order, funcs[ia : ix + 1], knots[ia:ix]
+                )
 
     if result_is_scalar:
         return int_f[0]
@@ -353,10 +356,17 @@ def indicator_if(a, x, order, b, l_close=True, r_close=False):
     if order == 0:
         return indicator_f(x, b, l_close=l_close, r_close=r_close)
     else:
-        return pieces_if(a, x, order,
-                         [lambda *params: constant_if(*params, 0.0),
-                          lambda *params: constant_if(*params, 1.0),
-                          lambda *params: constant_if(*params, 0.0)], b)
+        return pieces_if(
+            a,
+            x,
+            order,
+            [
+                lambda *params: constant_if(*params, 0.0),
+                lambda *params: constant_if(*params, 1.0),
+                lambda *params: constant_if(*params, 0.0),
+            ],
+            b,
+        )
 
 
 def seq_diff_mat(size):
@@ -398,7 +408,7 @@ def order_to_index(order, shape):
         tuple:
         The index element in the array.
     """
-    assert hasattr(shape, '__iter__')
+    assert hasattr(shape, "__iter__")
     assert isinstance(order, int)
     assert 0 <= order < np.prod(shape)
 
@@ -409,7 +419,7 @@ def order_to_index(order, shape):
     for j in range(ndim):
         quotient = order // n[j]
         index.append(quotient)
-        order -= quotient*n[j]
+        order -= quotient * n[j]
 
     return tuple(index)
 
@@ -431,9 +441,9 @@ def option_to_list(opt, size):
     assert isinstance(size, int)
     assert size > 0
     if not opt:
-        return [False]*size
+        return [False] * size
     else:
-        return [True]*size
+        return [True] * size
 
 
 def outer_flatten(*args):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,6 +8,7 @@ unit tests for xspline.core
 
 import numpy as np
 import pytest
+
 from xspline import core
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,11 +1,3 @@
-# -*- coding: utf-8 -*-
-"""
-test
-~~~~~~~~~
-
-unit tests for xspline.core
-"""
-
 import numpy as np
 import pytest
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """
-    test
-    ~~~~~~~~~
+test
+~~~~~~~~~
 
-    unit tests for xspline.core
+unit tests for xspline.core
 """
+
 import numpy as np
 import pytest
 from xspline import core
@@ -16,9 +17,9 @@ from xspline import core
 @pytest.mark.parametrize("l_extra", [False, True])
 @pytest.mark.parametrize("r_extra", [False, True])
 def test_bspline_domain(knots, degree, idx, l_extra, r_extra):
-    my_domain = core.bspline_domain(knots, degree, idx,
-                                    l_extra=l_extra,
-                                    r_extra=r_extra)
+    my_domain = core.bspline_domain(
+        knots, degree, idx, l_extra=l_extra, r_extra=r_extra
+    )
     if idx == 0:
         tr_domain = knots[:2].copy()
         if l_extra:
@@ -64,13 +65,13 @@ def test_bspline_domain_r_extra(knots, degree):
 def test_bspline_fun(x, knots, degree, idx):
     my_y = core.bspline_fun(x, knots, degree, idx)
     if idx == 0:
-        tr_y = np.maximum((knots[1] - x)/knots[1], 0.0)
+        tr_y = np.maximum((knots[1] - x) / knots[1], 0.0)
     else:
         tr_y = np.zeros(x.size)
         idx1 = (x >= knots[0]) & (x < knots[1])
         idx2 = (x >= knots[1]) & (x < knots[2])
-        tr_y[idx1] = x[idx1]/knots[1]
-        tr_y[idx2] = (knots[2] - x[idx2])/(knots[2] - knots[1])
+        tr_y[idx1] = x[idx1] / knots[1]
+        tr_y[idx2] = (knots[2] - x[idx2]) / (knots[2] - knots[1])
 
     assert np.linalg.norm(tr_y - my_y) < 1e-10
 
@@ -114,10 +115,10 @@ def test_bspline_dfun(x, knots, degree, order, idx):
     idx1 = (x >= knots[0]) & (x < knots[1])
     idx2 = (x >= knots[1]) & (x < knots[2])
     if idx == 0:
-        tr_dy[idx1] = -1.0/knots[1]
+        tr_dy[idx1] = -1.0 / knots[1]
     else:
-        tr_dy[idx1] = 1.0/knots[1]
-        tr_dy[idx2] = -1.0/(knots[2] - knots[1])
+        tr_dy[idx1] = 1.0 / knots[1]
+        tr_dy[idx2] = -1.0 / (knots[2] - knots[1])
 
     assert np.linalg.norm(tr_dy - my_dy) < 1e-10
 
@@ -129,10 +130,9 @@ def test_bspline_dfun_l_extra(x, knots, l_extra):
     degree = 1
     idx = 0
     order = 1
-    my_dy = core.bspline_dfun(x, knots, degree, order, idx,
-                              l_extra=l_extra)
+    my_dy = core.bspline_dfun(x, knots, degree, order, idx, l_extra=l_extra)
     if l_extra:
-        tr_dy = -1.0/knots[1]
+        tr_dy = -1.0 / knots[1]
     else:
         tr_dy = 0.0
 
@@ -146,10 +146,9 @@ def test_bspline_dfun_r_extra(x, knots, r_extra):
     degree = 1
     idx = -1
     order = 1
-    my_dy = core.bspline_dfun(x, knots, degree, order, idx,
-                              r_extra=r_extra)
+    my_dy = core.bspline_dfun(x, knots, degree, order, idx, r_extra=r_extra)
     if r_extra:
-        tr_dy = 1.0/(knots[-1] - knots[-2])
+        tr_dy = 1.0 / (knots[-1] - knots[-2])
     else:
         tr_dy = 0.0
     assert np.linalg.norm(my_dy - tr_dy) < 1e-10
@@ -165,7 +164,7 @@ def test_bspline_ifun(x, knots, degree, order, idx):
     tr_iy = np.zeros(x.size)
     idx1 = (x >= knots[0]) & (x <= knots[1])
 
-    tr_iy[idx1] = x[idx1] - 0.5/knots[1]*x[idx1]**2
+    tr_iy[idx1] = x[idx1] - 0.5 / knots[1] * x[idx1] ** 2
     tr_iy[~idx1] = tr_iy[idx1][-1]
 
     assert np.linalg.norm(tr_iy - my_iy) < 1e-10
@@ -178,8 +177,7 @@ def test_bspline_ifun_l_extra(x, knots, l_extra):
     degree = 0
     idx = 0
     order = 1
-    my_iy = core.bspline_ifun(x[0], x, knots, degree, order, idx,
-                              l_extra=l_extra)
+    my_iy = core.bspline_ifun(x[0], x, knots, degree, order, idx, l_extra=l_extra)
     if l_extra:
         tr_iy = x - x[0]
     else:
@@ -195,8 +193,7 @@ def test_bspline_ifun_r_extra(x, knots, r_extra):
     degree = 0
     idx = -1
     order = 1
-    my_iy = core.bspline_ifun(x[0], x, knots, degree, order, idx,
-                              r_extra=r_extra)
+    my_iy = core.bspline_ifun(x[0], x, knots, degree, order, idx, r_extra=r_extra)
     if r_extra:
         tr_iy = x - x[0]
     else:

--- a/tests/test_ndxspline.py
+++ b/tests/test_ndxspline.py
@@ -1,11 +1,3 @@
-# -*- coding: utf-8 -*-
-"""
-test_xspline
-~~~~~~~~~~~~
-
-Test XSpline class.
-"""
-
 import numpy as np
 import pytest
 

--- a/tests/test_ndxspline.py
+++ b/tests/test_ndxspline.py
@@ -1,20 +1,19 @@
 # -*- coding: utf-8 -*-
 """
-    test_xspline
-    ~~~~~~~~~~~~
+test_xspline
+~~~~~~~~~~~~
 
-    Test XSpline class.
+Test XSpline class.
 """
+
 import numpy as np
 import pytest
 from xspline import NDXSpline
 
+
 @pytest.fixture
 def spline():
-    knots = [
-        np.linspace(0.0, 1.0, 3),
-        np.linspace(0.0, 1.0, 2)
-    ]
+    knots = [np.linspace(0.0, 1.0, 3), np.linspace(0.0, 1.0, 2)]
     degree = [2, 3]
     return NDXSpline(2, knots, degree)
 
@@ -24,92 +23,97 @@ def test_ndim(spline):
 
 
 def test_num_knots(spline):
-    assert all([spline.num_knots_list[i] == spline.knots_list[i].size
-                for i in range(spline.ndim)])
+    assert all(
+        [
+            spline.num_knots_list[i] == spline.knots_list[i].size
+            for i in range(spline.ndim)
+        ]
+    )
     assert spline.num_knots == np.prod(spline.num_knots_list)
 
 
 def test_num_intervals(spline):
-    assert all([spline.num_intervals_list[i] == spline.knots_list[i].size - 1
-                for i in range(spline.ndim)])
+    assert all(
+        [
+            spline.num_intervals_list[i] == spline.knots_list[i].size - 1
+            for i in range(spline.ndim)
+        ]
+    )
     assert spline.num_intervals == np.prod(spline.num_intervals_list)
 
 
 def test_num_spline_bases(spline):
-    assert all([spline.num_spline_bases_list[i] ==
-                spline.spline_list[i].num_spline_bases
-                for i in range(spline.ndim)])
+    assert all(
+        [
+            spline.num_spline_bases_list[i] == spline.spline_list[i].num_spline_bases
+            for i in range(spline.ndim)
+        ]
+    )
     assert spline.num_spline_bases == np.prod(spline.num_spline_bases_list)
 
 
-@pytest.mark.parametrize('l_extra_list', [None,
-                                          [False, False],
-                                          [True, False],
-                                          [False, True],
-                                          [True, True]])
-@pytest.mark.parametrize('r_extra_list', [None,
-                                          [False, False],
-                                          [True, False],
-                                          [False, True],
-                                          [True, True]])
-@pytest.mark.parametrize('is_grid', [True, False])
+@pytest.mark.parametrize(
+    "l_extra_list", [None, [False, False], [True, False], [False, True], [True, True]]
+)
+@pytest.mark.parametrize(
+    "r_extra_list", [None, [False, False], [True, False], [False, True], [True, True]]
+)
+@pytest.mark.parametrize("is_grid", [True, False])
 def test_design_mat(spline, is_grid, l_extra_list, r_extra_list):
     x = np.linspace(0.0, 1.0, 11)
     y = np.linspace(0.0, 1.0, 11)
-    mat = spline.design_mat([x, y],
-                            is_grid=is_grid,
-                            l_extra_list=l_extra_list,
-                            r_extra_list=r_extra_list)
+    mat = spline.design_mat(
+        [x, y], is_grid=is_grid, l_extra_list=l_extra_list, r_extra_list=r_extra_list
+    )
     if is_grid:
-        assert mat.shape == (x.size*y.size, spline.num_spline_bases)
+        assert mat.shape == (x.size * y.size, spline.num_spline_bases)
     else:
         assert mat.shape == (x.size, spline.num_spline_bases)
 
 
-@pytest.mark.parametrize('l_extra_list', [None,
-                                          [False, False],
-                                          [True, False],
-                                          [False, True],
-                                          [True, True]])
-@pytest.mark.parametrize('r_extra_list', [None,
-                                          [False, False],
-                                          [True, False],
-                                          [False, True],
-                                          [True, True]])
-@pytest.mark.parametrize('is_grid', [True, False])
+@pytest.mark.parametrize(
+    "l_extra_list", [None, [False, False], [True, False], [False, True], [True, True]]
+)
+@pytest.mark.parametrize(
+    "r_extra_list", [None, [False, False], [True, False], [False, True], [True, True]]
+)
+@pytest.mark.parametrize("is_grid", [True, False])
 def test_design_dmat(spline, is_grid, l_extra_list, r_extra_list):
     x = np.linspace(0.0, 1.0, 11)
     y = np.linspace(0.0, 1.0, 11)
-    dmat = spline.design_dmat([x, y], [1, 1],
-                              is_grid=is_grid,
-                              l_extra_list=l_extra_list,
-                              r_extra_list=r_extra_list)
+    dmat = spline.design_dmat(
+        [x, y],
+        [1, 1],
+        is_grid=is_grid,
+        l_extra_list=l_extra_list,
+        r_extra_list=r_extra_list,
+    )
     if is_grid:
-        assert dmat.shape == (x.size*y.size, spline.num_spline_bases)
+        assert dmat.shape == (x.size * y.size, spline.num_spline_bases)
     else:
         assert dmat.shape == (x.size, spline.num_spline_bases)
 
 
-@pytest.mark.parametrize('l_extra_list', [None,
-                                          [False, False],
-                                          [True, False],
-                                          [False, True],
-                                          [True, True]])
-@pytest.mark.parametrize('r_extra_list', [None,
-                                          [False, False],
-                                          [True, False],
-                                          [False, True],
-                                          [True, True]])
-@pytest.mark.parametrize('is_grid', [True, False])
+@pytest.mark.parametrize(
+    "l_extra_list", [None, [False, False], [True, False], [False, True], [True, True]]
+)
+@pytest.mark.parametrize(
+    "r_extra_list", [None, [False, False], [True, False], [False, True], [True, True]]
+)
+@pytest.mark.parametrize("is_grid", [True, False])
 def test_design_imat(spline, is_grid, l_extra_list, r_extra_list):
     x = np.linspace(0.0, 1.0, 11)
     y = np.linspace(0.0, 1.0, 11)
-    imat = spline.design_imat([x, y], [x, y], [1, 1],
-                              is_grid=is_grid,
-                              l_extra_list=l_extra_list,
-                              r_extra_list=r_extra_list)
+    imat = spline.design_imat(
+        [x, y],
+        [x, y],
+        [1, 1],
+        is_grid=is_grid,
+        l_extra_list=l_extra_list,
+        r_extra_list=r_extra_list,
+    )
     assert np.allclose(imat, 0.0)
     if is_grid:
-        assert imat.shape == (x.size*y.size, spline.num_spline_bases)
+        assert imat.shape == (x.size * y.size, spline.num_spline_bases)
     else:
         assert imat.shape == (x.size, spline.num_spline_bases)

--- a/tests/test_ndxspline.py
+++ b/tests/test_ndxspline.py
@@ -8,6 +8,7 @@ Test XSpline class.
 
 import numpy as np
 import pytest
+
 from xspline import NDXSpline
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,62 +1,76 @@
 # -*- coding: utf-8 -*-
 """
-    test_utils
-    ~~~~~~~~~~
+test_utils
+~~~~~~~~~~
 
-    unit tests for xspline.utils
+unit tests for xspline.utils
 """
+
 import numpy as np
 import pytest
+
 from xspline import utils
 
 
-@pytest.mark.parametrize(("x", "l_close", "r_close", "result"),
-                         [(0.5, False, False, 1.0),
-                          (2.0, False, False, 0.0),
-                          (1.0, False, False, 0.0),
-                          (1.0, False, True, 1.0),
-                          (0.0, False, False, 0.0),
-                          (0.0, True, False, 1.0),
-                          (np.repeat(0.5, 3), False, False, np.ones(3)),
-                          (np.repeat(2.0, 3), False, False, np.zeros(3)),
-                          (np.repeat(1.0, 3), False, False, np.zeros(3)),
-                          (np.repeat(1.0, 3), False, True, np.ones(3)),
-                          (np.repeat(0.0, 3), False, False, np.zeros(3)),
-                          (np.repeat(0.0, 3), True, False, np.ones(3))])
+@pytest.mark.parametrize(
+    ("x", "l_close", "r_close", "result"),
+    [
+        (0.5, False, False, 1.0),
+        (2.0, False, False, 0.0),
+        (1.0, False, False, 0.0),
+        (1.0, False, True, 1.0),
+        (0.0, False, False, 0.0),
+        (0.0, True, False, 1.0),
+        (np.repeat(0.5, 3), False, False, np.ones(3)),
+        (np.repeat(2.0, 3), False, False, np.zeros(3)),
+        (np.repeat(1.0, 3), False, False, np.zeros(3)),
+        (np.repeat(1.0, 3), False, True, np.ones(3)),
+        (np.repeat(0.0, 3), False, False, np.zeros(3)),
+        (np.repeat(0.0, 3), True, False, np.ones(3)),
+    ],
+)
 def test_utils_indicator_f(x, l_close, r_close, result):
     b = np.array([0.0, 1.0])
     my_result = utils.indicator_f(x, b, l_close=l_close, r_close=r_close)
     assert np.linalg.norm(my_result - result) < 1e-10
 
 
-@pytest.mark.parametrize(("x", "z", "fz", "dfz"),
-                         [(1.0, 0.0, -1.0, 2.0),
-                          (np.ones(5), 0.0, -1.0, 2.0),
-                          (np.ones(5),
-                           np.zeros(5), np.repeat(-1.0, 5), np.repeat(2.0, 5)),
-                          (1.0,
-                           np.zeros(5), np.repeat(-1.0, 5), np.repeat(2.0, 5))])
+@pytest.mark.parametrize(
+    ("x", "z", "fz", "dfz"),
+    [
+        (1.0, 0.0, -1.0, 2.0),
+        (np.ones(5), 0.0, -1.0, 2.0),
+        (np.ones(5), np.zeros(5), np.repeat(-1.0, 5), np.repeat(2.0, 5)),
+        (1.0, np.zeros(5), np.repeat(-1.0, 5), np.repeat(2.0, 5)),
+    ],
+)
 def test_utils_linear_f(x, z, fz, dfz):
-    result = fz + dfz*(x - z)
+    result = fz + dfz * (x - z)
     my_result = utils.linear_f(x, z, fz, dfz)
     assert np.linalg.norm(my_result - result) < 1e-10
 
 
-@pytest.mark.parametrize(("x", "b", "result"),
-                         [(0.0, np.array([0.0, 1.0]), 0.0),
-                          (1.0, np.array([0.0, 1.0]), 1.0),
-                          (np.repeat(0.5, 5), np.array([0.0, 1.0]),
-                           np.repeat(0.5, 5))])
+@pytest.mark.parametrize(
+    ("x", "b", "result"),
+    [
+        (0.0, np.array([0.0, 1.0]), 0.0),
+        (1.0, np.array([0.0, 1.0]), 1.0),
+        (np.repeat(0.5, 5), np.array([0.0, 1.0]), np.repeat(0.5, 5)),
+    ],
+)
 def test_utils_linear_lf(x, b, result):
     my_result = utils.linear_lf(x, b)
     assert np.linalg.norm(my_result - result) < 1e-10
 
 
-@pytest.mark.parametrize(("x", "b", "result"),
-                         [(0.0, np.array([0.0, 1.0]), 1.0),
-                          (1.0, np.array([0.0, 1.0]), 0.0),
-                          (np.repeat(0.5, 5), np.array([0.0, 1.0]),
-                           np.repeat(0.5, 5))])
+@pytest.mark.parametrize(
+    ("x", "b", "result"),
+    [
+        (0.0, np.array([0.0, 1.0]), 1.0),
+        (1.0, np.array([0.0, 1.0]), 0.0),
+        (np.repeat(0.5, 5), np.array([0.0, 1.0]), np.repeat(0.5, 5)),
+    ],
+)
 def test_utils_linear_rf(x, b, result):
     my_result = utils.linear_rf(x, b)
     assert np.linalg.norm(my_result - result) < 1e-10
@@ -72,19 +86,16 @@ def test_utils_constant_if_0(a, x, order):
 
 @pytest.mark.parametrize("a", [0.0, np.zeros(5)])
 @pytest.mark.parametrize("x", [1.0, np.ones(5)])
-@pytest.mark.parametrize(("order", "result"),
-                         [(1, 1.0), (2, 0.5)])
+@pytest.mark.parametrize(("order", "result"), [(1, 1.0), (2, 0.5)])
 def test_utils_constant_if_1(a, x, order, result):
     my_result = utils.constant_if(a, x, order, 1.0)
     assert np.linalg.norm(my_result - result) < 1e-10
 
 
-@pytest.mark.parametrize(("z", "fz", "dfz"),
-                         [(1.0, 0.0, 2.0)])
+@pytest.mark.parametrize(("z", "fz", "dfz"), [(1.0, 0.0, 2.0)])
 @pytest.mark.parametrize("a", [0.0, np.zeros(5)])
 @pytest.mark.parametrize("x", [1.0, np.ones(5)])
-@pytest.mark.parametrize(("order", "result"),
-                         [(0, 0.0), (1, -1.0), (2, -2.0/3.0)])
+@pytest.mark.parametrize(("order", "result"), [(0, 0.0), (1, -1.0), (2, -2.0 / 3.0)])
 def test_utils_linear_if(a, x, order, z, fz, dfz, result):
     my_result = utils.linear_if(a, x, order, z, fz, dfz)
     assert np.linalg.norm(my_result - result) < 1e-10
@@ -93,16 +104,19 @@ def test_utils_linear_if(a, x, order, z, fz, dfz, result):
 @pytest.mark.parametrize("a", [0.0, np.zeros(5)])
 @pytest.mark.parametrize("x", [1.0, np.ones(5)])
 @pytest.mark.parametrize("knots", [np.array([0.5])])
-@pytest.mark.parametrize(("order", "result"),
-                         [(0, 2.0), (1, 1.5), (2, 0.625), (3, 3.0/16.0)])
+@pytest.mark.parametrize(
+    ("order", "result"), [(0, 2.0), (1, 1.5), (2, 0.625), (3, 3.0 / 16.0)]
+)
 def test_utils_integrate_across_pieces(a, x, order, knots, result):
     my_result = utils.integrate_across_pieces(
-        a, x, order,
+        a,
+        x,
+        order,
         [
             lambda *params: utils.constant_if(*params, 1.0),
             lambda *params: utils.constant_if(*params, 2.0),
         ],
-        knots
+        knots,
     )
     assert np.linalg.norm(my_result - result) < 1e-10
 
@@ -110,18 +124,21 @@ def test_utils_integrate_across_pieces(a, x, order, knots, result):
 @pytest.mark.parametrize("a", [0.0, np.zeros(5)])
 @pytest.mark.parametrize("x", [1.0, np.ones(5)])
 @pytest.mark.parametrize("knots", [np.array([0.0, 0.5, 1.0])])
-@pytest.mark.parametrize(("order", "result"),
-                         [(0, 2.0), (1, 1.5), (2, 0.625), (3, 3.0/16.0)])
+@pytest.mark.parametrize(
+    ("order", "result"), [(0, 2.0), (1, 1.5), (2, 0.625), (3, 3.0 / 16.0)]
+)
 def test_utils_pieces_if(a, x, order, knots, result):
     my_result = utils.pieces_if(
-        a, x, order,
+        a,
+        x,
+        order,
         [
             lambda *params: utils.constant_if(*params, 0.0),
             lambda *params: utils.constant_if(*params, 1.0),
             lambda *params: utils.constant_if(*params, 2.0),
             lambda *params: utils.constant_if(*params, 0.0),
         ],
-        knots
+        knots,
     )
     assert np.linalg.norm(my_result - result) < 1e-10
 
@@ -129,8 +146,7 @@ def test_utils_pieces_if(a, x, order, knots, result):
 @pytest.mark.parametrize("a", [0.0, np.zeros(5)])
 @pytest.mark.parametrize("x", [1.0, np.ones(5)])
 @pytest.mark.parametrize("b", [np.array([0.5, 1.0])])
-@pytest.mark.parametrize(("order", "result"),
-                         [(0, 0.0), (1, 0.5), (2, 0.125)])
+@pytest.mark.parametrize(("order", "result"), [(0, 0.0), (1, 0.5), (2, 0.125)])
 def test_utils_indicator_if(a, x, order, b, result):
     my_result = utils.indicator_if(a, x, order, b)
     assert np.linalg.norm(my_result - result) < 1e-10
@@ -139,7 +155,7 @@ def test_utils_indicator_if(a, x, order, b, result):
 @pytest.mark.parametrize("size", [5, 10])
 def test_utils_seq_diff_mat(size):
     x = np.random.randn(size)
-    y = np.array([x[i+1] - x[i] for i in range(size - 1)])
+    y = np.array([x[i + 1] - x[i] for i in range(size - 1)])
 
     mat = utils.seq_diff_mat(size)
     my_y = mat.dot(x)
@@ -165,9 +181,9 @@ def test_utils_option_to_list(option, size):
     assert all([~(my_result[i] ^ result) for i in range(size)])
 
 
-@pytest.mark.parametrize("args",
-                         [(np.arange(2), np.arange(3)),
-                          (np.arange(2), np.arange(3), np.arange(4))])
+@pytest.mark.parametrize(
+    "args", [(np.arange(2), np.arange(3)), (np.arange(2), np.arange(3), np.arange(4))]
+)
 def test_utils_outer_flatten(args):
     if len(args) < 2:
         raise ValueError("Must have more than 2 arguments for outer_flatten.")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,3 @@
-# -*- coding: utf-8 -*-
-"""
-test_utils
-~~~~~~~~~~
-
-unit tests for xspline.utils
-"""
-
 import numpy as np
 import pytest
 

--- a/tests/test_xspline.py
+++ b/tests/test_xspline.py
@@ -1,11 +1,3 @@
-# -*- coding: utf-8 -*-
-"""
-test_xspline
-~~~~~~~~~~~~
-
-Test XSpline class.
-"""
-
 import numpy as np
 import pytest
 
@@ -106,7 +98,7 @@ def test_ifun(knots, degree, order, idx, l_linear, r_linear, l_extra, r_extra):
         x = np.linspace(xs.knots[0] - 1.0, xs.knots[1], 101)
     else:
         x = np.linspace(xs.knots[-2], xs.knots[-1], 101)
-    my_iy = xs.ifun(x[0], x, order, idx, l_extra=l_extra, r_extra=r_extra)
+    _ = xs.ifun(x[0], x, order, idx, l_extra=l_extra, r_extra=r_extra)
 
     domain = xs.domain(idx, l_extra=l_extra, r_extra=r_extra)
     lb = domain[0]

--- a/tests/test_xspline.py
+++ b/tests/test_xspline.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """
-    test_xspline
-    ~~~~~~~~~~~~
+test_xspline
+~~~~~~~~~~~~
 
-    Test XSpline class.
+Test XSpline class.
 """
+
 import numpy as np
 import pytest
 from xspline.core import XSpline
@@ -55,13 +56,11 @@ def test_fun(knots, degree, idx, l_linear, r_linear, l_extra, r_extra):
     my_y = xs.fun(x, idx, l_extra=l_extra, r_extra=r_extra)
 
     if idx == 0:
-        tr_y = (xs.inner_knots[1] - x) / \
-               (xs.inner_knots[1] - xs.inner_knots[0])
+        tr_y = (xs.inner_knots[1] - x) / (xs.inner_knots[1] - xs.inner_knots[0])
         if not l_extra:
             tr_y[x < xs.knots[0]] = 0.0
     else:
-        tr_y = (x - xs.inner_knots[-2]) / \
-               (xs.inner_knots[-1] - xs.inner_knots[-2])
+        tr_y = (x - xs.inner_knots[-2]) / (xs.inner_knots[-1] - xs.inner_knots[-2])
         if not r_extra:
             tr_y[x > xs.knots[-1]] = 0.0
 
@@ -83,11 +82,11 @@ def test_dfun(knots, degree, order, idx, l_linear, r_linear, l_extra, r_extra):
     my_dy = xs.dfun(x, order, idx, l_extra=l_extra, r_extra=r_extra)
 
     if idx == 0:
-        tr_dy = np.repeat(1.0/(xs.inner_knots[0] - xs.inner_knots[1]), x.size)
+        tr_dy = np.repeat(1.0 / (xs.inner_knots[0] - xs.inner_knots[1]), x.size)
         if not l_extra:
             tr_dy[x < xs.knots[0]] = 0.0
     else:
-        tr_dy = np.repeat(1.0/(xs.inner_knots[-1] - xs.inner_knots[-2]), x.size)
+        tr_dy = np.repeat(1.0 / (xs.inner_knots[-1] - xs.inner_knots[-2]), x.size)
         if not r_extra:
             tr_dy[x > xs.knots[-1]] = 0.0
 
@@ -115,13 +114,21 @@ def test_ifun(knots, degree, order, idx, l_linear, r_linear, l_extra, r_extra):
     tr_iy = np.zeros(x.size)
 
     if idx == 0:
+
         def ifun(a):
-            return 0.5*(xs.inner_knots[1] - a)**2 / \
-                   (xs.inner_knots[0] - xs.inner_knots[1])
+            return (
+                0.5
+                * (xs.inner_knots[1] - a) ** 2
+                / (xs.inner_knots[0] - xs.inner_knots[1])
+            )
     else:
+
         def ifun(a):
-            return 0.5*(a - xs.inner_knots[-2])**2 / \
-                   (xs.inner_knots[-1] - xs.inner_knots[-2])
+            return (
+                0.5
+                * (a - xs.inner_knots[-2]) ** 2
+                / (xs.inner_knots[-1] - xs.inner_knots[-2])
+            )
 
     tr_iy[v_idx] = ifun(x[v_idx]) - ifun(lb)
 
@@ -130,9 +137,14 @@ def test_ifun(knots, degree, order, idx, l_linear, r_linear, l_extra, r_extra):
 @pytest.mark.parametrize("r_linear", [True, False])
 @pytest.mark.parametrize("l_extra", [True, False])
 @pytest.mark.parametrize("r_extra", [True, False])
-@pytest.mark.parametrize("x", [np.linspace(0.0, 1.0, 100),
-                               np.linspace(-1.0, 0.5, 100),
-                               np.linspace(0.5, 2.0, 100)])
+@pytest.mark.parametrize(
+    "x",
+    [
+        np.linspace(0.0, 1.0, 100),
+        np.linspace(-1.0, 0.5, 100),
+        np.linspace(0.5, 2.0, 100),
+    ],
+)
 def test_design_mat(knots, degree, x, l_linear, r_linear, l_extra, r_extra):
     xs = XSpline(knots, degree, l_linear=l_linear, r_linear=r_linear)
     mat = xs.design_mat(x, l_extra=l_extra, r_extra=r_extra)
@@ -145,11 +157,15 @@ def test_design_mat(knots, degree, x, l_linear, r_linear, l_extra, r_extra):
 @pytest.mark.parametrize("l_extra", [True, False])
 @pytest.mark.parametrize("r_extra", [True, False])
 @pytest.mark.parametrize("order", [1])
-@pytest.mark.parametrize("x", [np.linspace(0.0, 1.0, 100),
-                               np.linspace(-1.0, 0.5, 100),
-                               np.linspace(0.5, 2.0, 100)])
-def test_design_dmat(knots, degree, order, x,
-                     l_linear, r_linear, l_extra, r_extra):
+@pytest.mark.parametrize(
+    "x",
+    [
+        np.linspace(0.0, 1.0, 100),
+        np.linspace(-1.0, 0.5, 100),
+        np.linspace(0.5, 2.0, 100),
+    ],
+)
+def test_design_dmat(knots, degree, order, x, l_linear, r_linear, l_extra, r_extra):
     xs = XSpline(knots, degree, l_linear=l_linear, r_linear=r_linear)
     dmat = xs.design_dmat(x, order, l_extra=l_extra, r_extra=r_extra)
 
@@ -161,11 +177,15 @@ def test_design_dmat(knots, degree, order, x,
 @pytest.mark.parametrize("l_extra", [True, False])
 @pytest.mark.parametrize("r_extra", [True, False])
 @pytest.mark.parametrize("order", [1])
-@pytest.mark.parametrize("x", [np.linspace(0.0, 1.0, 100),
-                               np.linspace(-1.0, 0.5, 100),
-                               np.linspace(0.5, 2.0, 100)])
-def test_design_imat(knots, degree, order, x,
-                     l_linear, r_linear, l_extra, r_extra):
+@pytest.mark.parametrize(
+    "x",
+    [
+        np.linspace(0.0, 1.0, 100),
+        np.linspace(-1.0, 0.5, 100),
+        np.linspace(0.5, 2.0, 100),
+    ],
+)
+def test_design_imat(knots, degree, order, x, l_linear, r_linear, l_extra, r_extra):
     xs = XSpline(knots, degree, l_linear=l_linear, r_linear=r_linear)
     imat = xs.design_imat(x[0], x, order, l_extra=l_extra, r_extra=r_extra)
 
@@ -178,8 +198,9 @@ def test_last_dmat(knots, degree, l_linear, r_linear):
     xs = XSpline(knots, degree, l_linear=l_linear, r_linear=r_linear)
     my_last_dmat = xs.last_dmat()
 
-    x = np.array([0.5*(xs.knots[i] + xs.knots[i+1])
-                  for i in range(xs.knots.size - 1)])
+    x = np.array(
+        [0.5 * (xs.knots[i] + xs.knots[i + 1]) for i in range(xs.knots.size - 1)]
+    )
     tr_last_dmat = xs.design_dmat(x, 1)
 
     assert np.linalg.norm(my_last_dmat - tr_last_dmat) < 1e-10

--- a/tests/test_xspline.py
+++ b/tests/test_xspline.py
@@ -8,6 +8,7 @@ Test XSpline class.
 
 import numpy as np
 import pytest
+
 from xspline.core import XSpline
 
 


### PR DESCRIPTION
## Summary

A formatting and documentation cleanup pass on top of the numpy 2
compatibility fixes. No runtime behavior changes — this is purely
style, docstrings, and lint hygiene.

- Apply `ruff format` across the package, tests, and `setup.py`
  (quote style, spacing, line wrapping).
- Convert all docstrings from Google style (`Args:`/`Returns:`) to
  NumPy style (`Parameters`/`Returns` with underlines).
- Tidy imports and the public API surface.

## What changed

- **Docstrings** (`src/xspline/core.py`, `src/xspline/utils.py`) —
  converted every function/method to NumPy style. Argument types are
  dropped from the docstrings (to be carried by type hints later);
  return types are kept. `XSpline` / `NDXSpline` constructor
  parameters moved into the class docstring with an `Attributes`
  section. Dropped the `r"""` prefixes (no docstring uses backslashes)
  and removed the module-level docstrings/header comments.
- **Imports & public API** (`src/xspline/__init__.py`) — replaced
  `from .core import *` with explicit imports and an explicit
  `__all__` listing the four `bspline_*` functions and the `XSpline` /
  `NDXSpline` classes.
- **Formatting** (`setup.py`, `src/xspline/__about__.py`, all of
  `tests/`) — `ruff format` reflow and import-order fixes; removed an
  unused variable in `tests/test_xspline.py`.
