### PR TITLE
Typehint

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: "3.11"
     - name: Install dependencies
       run: python -m pip install .[dev] --upgrade pip
     - name: Test with pytest
@@ -22,7 +22,7 @@ jobs:
         python -m build --sdist --wheel --outdir dist/ .
     - name: Publish package distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         skip_existing: true
         user: __token__

--- a/src/xspline/core.py
+++ b/src/xspline/core.py
@@ -1,9 +1,16 @@
 import numpy as np
+import numpy.typing as npt
 
 from . import utils
 
 
-def bspline_domain(knots, degree, idx, l_extra=False, r_extra=False):
+def bspline_domain(
+    knots: npt.NDArray,
+    degree: int,
+    idx: int,
+    l_extra: bool = False,
+    r_extra: bool = False,
+) -> npt.NDArray:
     """Compute the support for the spline basis, knots degree and the index of
     the basis.
 
@@ -47,7 +54,14 @@ def bspline_domain(knots, degree, idx, l_extra=False, r_extra=False):
     return np.array([lb, ub])
 
 
-def bspline_fun(x, knots, degree, idx, l_extra=False, r_extra=False):
+def bspline_fun(
+    x: float | npt.NDArray,
+    knots: npt.NDArray,
+    degree: int,
+    idx: int,
+    l_extra: bool = False,
+    r_extra: bool = False,
+) -> float | npt.NDArray:
     """Compute the spline basis.
 
     Parameters
@@ -107,7 +121,15 @@ def bspline_fun(x, knots, degree, idx, l_extra=False, r_extra=False):
     return lf + rf
 
 
-def bspline_dfun(x, knots, degree, order, idx, l_extra=False, r_extra=False):
+def bspline_dfun(
+    x: float | npt.NDArray,
+    knots: npt.NDArray,
+    degree: int,
+    order: int,
+    idx: int,
+    l_extra: bool = False,
+    r_extra: bool = False,
+) -> float | npt.NDArray:
     """Compute the derivative of the spline basis.
 
     Parameters
@@ -194,7 +216,16 @@ def bspline_dfun(x, knots, degree, order, idx, l_extra=False, r_extra=False):
     return ldf + rdf
 
 
-def bspline_ifun(a, x, knots, degree, order, idx, l_extra=False, r_extra=False):
+def bspline_ifun(
+    a: float | npt.NDArray,
+    x: float | npt.NDArray,
+    knots: npt.NDArray,
+    degree: int,
+    order: int,
+    idx: int,
+    l_extra: bool = False,
+    r_extra: bool = False,
+) -> float | npt.NDArray:
     """Compute the integral of the spline basis.
 
     Parameters
@@ -337,12 +368,12 @@ class XSpline:
 
     def __init__(
         self,
-        knots,
-        degree,
-        l_linear=False,
-        r_linear=False,
+        knots: npt.ArrayLike,
+        degree: int,
+        l_linear: bool = False,
+        r_linear: bool = False,
         include_first_basis: bool = True,
-    ):
+    ) -> None:
         """Constructor of the XSpline class."""
         # pre-process the knots vector
         knots = list(set(knots))
@@ -375,7 +406,9 @@ class XSpline:
             self.inner_knots.size - 1 + self.degree - self.basis_start
         )
 
-    def domain(self, idx, l_extra=False, r_extra=False):
+    def domain(
+        self, idx: int, l_extra: bool = False, r_extra: bool = False
+    ) -> npt.NDArray:
         """Return the support of the XSpline.
 
         Parameters
@@ -407,7 +440,13 @@ class XSpline:
 
         return np.array([lb, ub])
 
-    def fun(self, x, idx, l_extra=False, r_extra=False):
+    def fun(
+        self,
+        x: float | npt.NDArray,
+        idx: int,
+        l_extra: bool = False,
+        r_extra: bool = False,
+    ) -> float | npt.NDArray:
         """Compute the spline basis.
 
         Parameters
@@ -481,7 +520,14 @@ class XSpline:
         else:
             return f
 
-    def dfun(self, x, order, idx, l_extra=False, r_extra=False):
+    def dfun(
+        self,
+        x: float | npt.NDArray,
+        order: int,
+        idx: int,
+        l_extra: bool = False,
+        r_extra: bool = False,
+    ) -> float | npt.NDArray:
         """Compute the derivative of the spline basis.
 
         Parameters
@@ -555,7 +601,15 @@ class XSpline:
         else:
             return dy
 
-    def ifun(self, a, x, order, idx, l_extra=False, r_extra=False):
+    def ifun(
+        self,
+        a: float | npt.NDArray,
+        x: float | npt.NDArray,
+        order: int,
+        idx: int,
+        l_extra: bool = False,
+        r_extra: bool = False,
+    ) -> float | npt.NDArray:
         """Compute the integral of the spline basis.
 
         Parameters
@@ -607,10 +661,14 @@ class XSpline:
         inner_ub_dy = bspline_dfun(self.inner_ub, self.inner_knots, self.degree, 1, idx)
 
         # there are in total 5 pieces functions
-        def l_piece(a, x, order):
+        def l_piece(
+            a: float | npt.NDArray, x: float | npt.NDArray, order: int
+        ) -> float | npt.NDArray:
             return utils.linear_if(a, x, order, self.inner_lb, inner_lb_y, inner_lb_dy)
 
-        def m_piece(a, x, order):
+        def m_piece(
+            a: float | npt.NDArray, x: float | npt.NDArray, order: int
+        ) -> float | npt.NDArray:
             return bspline_ifun(
                 a,
                 x,
@@ -622,10 +680,14 @@ class XSpline:
                 r_extra=r_extra,
             )
 
-        def r_piece(a, x, order):
+        def r_piece(
+            a: float | npt.NDArray, x: float | npt.NDArray, order: int
+        ) -> float | npt.NDArray:
             return utils.linear_if(a, x, order, self.inner_ub, inner_ub_y, inner_ub_dy)
 
-        def zero_piece(a, x, order):
+        def zero_piece(
+            a: float | npt.NDArray, x: float | npt.NDArray, order: int
+        ) -> float | npt.NDArray:
             if np.isscalar(a) and np.isscalar(x):
                 return 0.0
             elif np.isscalar(a):
@@ -660,7 +722,9 @@ class XSpline:
 
         return utils.pieces_if(a, x, order, funcs, knots)
 
-    def design_mat(self, x, l_extra=False, r_extra=False):
+    def design_mat(
+        self, x: float | npt.NDArray, l_extra: bool = False, r_extra: bool = False
+    ) -> npt.NDArray:
         """Compute the design matrix of spline basis.
 
         Parameters
@@ -689,7 +753,13 @@ class XSpline:
         ).T
         return mat
 
-    def design_dmat(self, x, order, l_extra=False, r_extra=False):
+    def design_dmat(
+        self,
+        x: float | npt.NDArray,
+        order: int,
+        l_extra: bool = False,
+        r_extra: bool = False,
+    ) -> npt.NDArray:
         """Compute the design matrix of spline basis derivatives.
 
         Parameters
@@ -720,7 +790,14 @@ class XSpline:
         ).T
         return dmat
 
-    def design_imat(self, a, x, order, l_extra=False, r_extra=False):
+    def design_imat(
+        self,
+        a: float | npt.NDArray,
+        x: float | npt.NDArray,
+        order: int,
+        l_extra: bool = False,
+        r_extra: bool = False,
+    ) -> npt.NDArray:
         """Compute the design matrix of the integrals of the spline bases.
 
         Parameters
@@ -755,7 +832,7 @@ class XSpline:
         ).T
         return imat
 
-    def last_dmat(self):
+    def last_dmat(self) -> npt.NDArray:
         """Compute highest order of derivative in domain.
 
         Returns
@@ -825,13 +902,13 @@ class NDXSpline:
 
     def __init__(
         self,
-        ndim,
-        knots_list,
-        degree_list,
-        l_linear_list=None,
-        r_linear_list=None,
-        include_first_basis_list=True,
-    ):
+        ndim: int,
+        knots_list: list[npt.ArrayLike],
+        degree_list: list[int],
+        l_linear_list: bool | list[bool] | None = None,
+        r_linear_list: bool | list[bool] | None = None,
+        include_first_basis_list: bool | list[bool] | None = True,
+    ) -> None:
         """Constructor of ndXSpline class."""
         self.ndim = ndim
         self.knots_list = knots_list
@@ -867,7 +944,13 @@ class NDXSpline:
         self.num_intervals = self.num_intervals_list.prod()
         self.num_spline_bases = self.num_spline_bases_list.prod()
 
-    def design_mat(self, x_list, is_grid=True, l_extra_list=None, r_extra_list=None):
+    def design_mat(
+        self,
+        x_list: list[npt.NDArray],
+        is_grid: bool = True,
+        l_extra_list: bool | list[bool] | None = None,
+        r_extra_list: bool | list[bool] | None = None,
+    ) -> npt.NDArray:
         """Design matrix of the spline basis.
 
         Parameters
@@ -921,8 +1004,13 @@ class NDXSpline:
         return np.ascontiguousarray(np.vstack(mat).T)
 
     def design_dmat(
-        self, x_list, n_list, is_grid=True, l_extra_list=None, r_extra_list=None
-    ):
+        self,
+        x_list: list[npt.NDArray],
+        n_list: list[int],
+        is_grid: bool = True,
+        l_extra_list: bool | list[bool] | None = None,
+        r_extra_list: bool | list[bool] | None = None,
+    ) -> npt.NDArray:
         """Design matrix of the derivatives of spline basis.
 
         Parameters
@@ -980,8 +1068,14 @@ class NDXSpline:
         return np.ascontiguousarray(np.vstack(dmat).T)
 
     def design_imat(
-        self, a_list, x_list, n_list, is_grid=True, l_extra_list=None, r_extra_list=None
-    ):
+        self,
+        a_list: list[npt.NDArray],
+        x_list: list[npt.NDArray],
+        n_list: list[int],
+        is_grid: bool = True,
+        l_extra_list: bool | list[bool] | None = None,
+        r_extra_list: bool | list[bool] | None = None,
+    ) -> npt.NDArray:
         """Design matrix of the spline basis.
 
         Parameters
@@ -1045,7 +1139,7 @@ class NDXSpline:
 
         return np.ascontiguousarray(np.vstack(imat).T)
 
-    def last_dmat(self):
+    def last_dmat(self) -> npt.NDArray:
         """Highest order of derivative matrix.
 
         Returns

--- a/src/xspline/utils.py
+++ b/src/xspline/utils.py
@@ -1,10 +1,17 @@
 import functools
 import math
+from collections.abc import Callable
 
 import numpy as np
+import numpy.typing as npt
 
 
-def indicator_f(x, b, l_close=True, r_close=False):
+def indicator_f(
+    x: float | npt.NDArray,
+    b: npt.NDArray,
+    l_close: bool = True,
+    r_close: bool = False,
+) -> float | npt.NDArray:
     """Indicator function for provided interval.
 
     Parameters
@@ -42,7 +49,12 @@ def indicator_f(x, b, l_close=True, r_close=False):
         return (lb & rb).astype(np.double)
 
 
-def linear_f(x, z, fz, dfz):
+def linear_f(
+    x: float | npt.NDArray,
+    z: float | npt.NDArray,
+    fz: float | npt.NDArray,
+    dfz: float | npt.NDArray,
+) -> float | npt.NDArray:
     """Linear function construct by reference point(s).
 
     Parameters
@@ -69,7 +81,7 @@ def linear_f(x, z, fz, dfz):
     return fz + dfz * (x - z)
 
 
-def linear_lf(x, b):
+def linear_lf(x: float | npt.NDArray, b: npt.NDArray) -> float | npt.NDArray:
     """Linear function constructed by linearly interpolate 0 and 1 from left
     end point to right end point.
 
@@ -90,7 +102,7 @@ def linear_lf(x, b):
     return (x - b[0]) / (b[1] - b[0])
 
 
-def linear_rf(x, b):
+def linear_rf(x: float | npt.NDArray, b: npt.NDArray) -> float | npt.NDArray:
     """Linear function constructed by linearly interpolate 0 and 1 from right
     end point to left end point.
 
@@ -111,7 +123,12 @@ def linear_rf(x, b):
     return (x - b[1]) / (b[0] - b[1])
 
 
-def constant_if(a, x, order, c):
+def constant_if(
+    a: float | npt.NDArray,
+    x: float | npt.NDArray,
+    order: int,
+    c: float,
+) -> float | npt.NDArray:
     """Integration of constant function.
 
     Parameters
@@ -158,7 +175,14 @@ def constant_if(a, x, order, c):
     return c * (x - a) ** order / math.factorial(order)
 
 
-def linear_if(a, x, order, z, fz, dfz):
+def linear_if(
+    a: float | npt.NDArray,
+    x: float | npt.NDArray,
+    order: int,
+    z: float | npt.NDArray,
+    fz: float | npt.NDArray,
+    dfz: float | npt.NDArray,
+) -> float | npt.NDArray:
     """Integrate linear function constructed by the reference point(s).
 
     Parameters
@@ -195,7 +219,13 @@ def linear_if(a, x, order, z, fz, dfz):
     ) ** order / math.factorial(order)
 
 
-def integrate_across_pieces(a, x, order, funcs, knots):
+def integrate_across_pieces(
+    a: float | npt.NDArray,
+    x: float | npt.NDArray,
+    order: int,
+    funcs: list[Callable[..., float | npt.NDArray]],
+    knots: npt.NDArray,
+) -> float | npt.NDArray:
     """Integrate Across piecewise functions.
 
     Parameters
@@ -243,7 +273,13 @@ def integrate_across_pieces(a, x, order, funcs, knots):
     return val
 
 
-def pieces_if(a, x, order, funcs, knots):
+def pieces_if(
+    a: float | npt.NDArray,
+    x: float | npt.NDArray,
+    order: int,
+    funcs: list[Callable[..., float | npt.NDArray]],
+    knots: npt.NDArray,
+) -> float | npt.NDArray:
     """Integrate pieces of the functions.
 
     Parameters
@@ -315,7 +351,14 @@ def pieces_if(a, x, order, funcs, knots):
         return int_f
 
 
-def indicator_if(a, x, order, b, l_close=True, r_close=False):
+def indicator_if(
+    a: float | npt.NDArray,
+    x: float | npt.NDArray,
+    order: int,
+    b: npt.NDArray,
+    l_close: bool = True,
+    r_close: bool = False,
+) -> float | npt.NDArray:
     """Integrate indicator function.
 
     Parameters
@@ -358,7 +401,7 @@ def indicator_if(a, x, order, b, l_close=True, r_close=False):
         )
 
 
-def seq_diff_mat(size):
+def seq_diff_mat(size: int) -> npt.NDArray:
     """Compute sequencial difference matrix.
 
     Parameters
@@ -384,7 +427,7 @@ def seq_diff_mat(size):
     return mat
 
 
-def order_to_index(order, shape):
+def order_to_index(order: int, shape: tuple[int, ...] | npt.NDArray) -> tuple[int, ...]:
     """Compute the index of the element in a high dimensional array provided
     the order of the element.
 
@@ -416,13 +459,15 @@ def order_to_index(order, shape):
     return tuple(index)
 
 
-def option_to_list(opt, size):
+def option_to_list(opt: bool | list[bool] | None, size: int) -> list[bool]:
     """Convert default option to list of options.
 
     Parameters
     ----------
     opt
-        A single option in the form of bool or None.
+        Option(s) in the form of a single bool, ``None``, or a list of bool
+        with length ``size``. ``None`` is treated as ``False`` and a single
+        bool is broadcast to every dimension.
     size
         Positive integer indicate the size of the option list.
 
@@ -433,13 +478,16 @@ def option_to_list(opt, size):
     """
     assert isinstance(size, int)
     assert size > 0
-    if not opt:
+    if opt is None:
         return [False] * size
-    else:
-        return [True] * size
+    if isinstance(opt, bool):
+        return [opt] * size
+    opt = list(opt)
+    assert len(opt) == size
+    return opt
 
 
-def outer_flatten(*args):
+def outer_flatten(*args: npt.NDArray) -> npt.NDArray:
     """Outer product of multiple vectors and then flatten the result.
 
     Parameters

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -167,10 +167,21 @@ def test_utils_order_to_index(order, shape):
 @pytest.mark.parametrize("option", [True, False, None])
 @pytest.mark.parametrize("size", [2, 3])
 def test_utils_option_to_list(option, size):
-    result = not option
+    expected = bool(option)
     my_result = utils.option_to_list(option, size)
-    assert len(my_result) == size
-    assert all([~(my_result[i] ^ result) for i in range(size)])
+    assert my_result == [expected] * size
+
+
+@pytest.mark.parametrize("size", [2, 3])
+def test_utils_option_to_list_with_list(size):
+    option = [i % 2 == 0 for i in range(size)]
+    my_result = utils.option_to_list(option, size)
+    assert my_result == option
+
+
+def test_utils_option_to_list_wrong_length():
+    with pytest.raises(AssertionError):
+        utils.option_to_list([True, False], 3)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Add type hints to the public functions and methods in `core.py` and
`utils.py`, and fix `option_to_list` so the per-dimension `*_list`
options actually work as documented. Also modernize the CI workflow,
which is required because the new typing syntax needs Python >= 3.10.

Typing conventions used:
- `numpy.typing.NDArray` for real arrays, `numpy.typing.ArrayLike` for
  the knot inputs that get normalized via `np.array`/`np.asarray`
  (the `XSpline` / `NDXSpline` constructors).
- `float | NDArray` (simple unions, no `@overload`) for the
  scalar-or-array math functions, matching how the code branches on
  `np.isscalar`.

## What changed

- **`src/xspline/utils.py`** — annotated all functions (args + returns).
  Notable: `order_to_index(shape)` is `tuple[int, ...] | NDArray`
  (tuple in tests, ndarray in `core.py`); `funcs` is
  `list[Callable[..., float | NDArray]]`; `outer_flatten(*args: NDArray)`.
- **`src/xspline/utils.py` (`option_to_list`)** — **behavior fix.**
  Previously any non-empty list was truthy and collapsed to all-`True`,
  so per-dimension lists were silently ignored. It now accepts a single
  `bool`, `None`, or a real `list[bool]` (length-checked), returning the
  list as-is. Signature: `bool | list[bool] | None`.
- **`src/xspline/core.py`** — annotated the four `bspline_*` functions,
  the `XSpline` / `NDXSpline` methods, constructors (`-> None`), and the
  nested integration piece helpers in `ifun`. The `*_list` /
  `*_extra_list` params are typed `bool | list[bool] | None` to keep the
  scalar/None convenience while enabling real lists.
- **`tests/test_utils.py`** — replaced the previously vacuous
  `test_utils_option_to_list` (its `~(a ^ b)` assertion was always
  truthy) with assertions that actually check the values, plus new tests
  for the real-list path and the length-mismatch guard.
- **`.github/workflows/python-build.yml`** — bumped the test Python to
  3.11 (the new `X | Y` / `list[bool]` syntax needs >= 3.10, which was
  the CI failure), and updated action versions:
  `actions/checkout@v2 -> v4`, `actions/setup-python@v2 -> v5`,
  `pypa/gh-action-pypi-publish@master -> @release/v1`.
